### PR TITLE
Feat/ltc6810 2 driver

### DIFF
--- a/include/drivers/ltc6810-2/ltc6810-2-api.h
+++ b/include/drivers/ltc6810-2/ltc6810-2-api.h
@@ -1,0 +1,772 @@
+/*!
+ * \file            ltc6810-2-api.h
+ * \date            2026-05-13
+ * \authors         Mirko Lana [mirko.lana@eagletrt.it]
+ *
+ * \brief           Function declarations needed for the LTC6810-2.
+ *
+ * \details         For additional information refer to the datasheet:
+ * \link            https://www.analog.com/media/en/technical-documentation/data-sheets/ltc6810-1-6810-2.pdf
+*/
+
+#ifndef LTC6810_2_API_H
+#define LTC6810_2_API_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ltc6810-2.h"
+
+/*!
+ * \brief           Initialize the IC handler structure
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       ltc_count: The total number of ICs in the chain
+ */
+void ltc6810_2_init(struct Ltc68102Handler *handler, size_t ltc_count);
+
+/*!
+ * \brief           Check if the ADC conversion has ended or not
+ *
+ * \warning         Do not pull the Chip Select(CS) high before the conversion
+ *                  has ended otherwise this command will not work
+ *
+ * \param[in]       byte: A byte read after the pladc command was sent
+ * \return          True if the conversion has ended, false otherwise
+ */
+bool ltc6810_2_pladc_is_completed(const uint8_t byte);
+
+/*!
+ * \brief           Encode the configuration data of the ICs into a broadcast
+ *                  write command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \warning         The \c config array size MUST be equal to the number of ICs
+ *                  in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       config: The configuration data array
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ */
+size_t ltc6810_2_wrcfg_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    struct Ltc68102Cfgr *config,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast configuration read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcfg_encode_broadcast(const struct Ltc68102Handler *handler, uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  configuration data
+ *
+ * \warning         The \c out array should be as large as the total number of
+ *                  ICs in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the configuration data is stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcfg_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    struct Ltc68102Cfgr *out);
+
+/*!
+ * \brief           Encode the broadcast cell voltage read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encode bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       reg: The register to read from
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcv_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Cvxr reg,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  cell voltages
+ *
+ * \warning         The \c out array should be large enough to store
+ *                  \c LTC6810_2_REG_CELL_COUNT voltages for each IC in the
+ *                  chain
+ *
+ * \details         Cell voltages are 16-bit values represented in mV * 10
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the cell voltages are stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcv_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint16_t *out);
+
+/*!
+ * \brief           Encode the broadcast auxiliary voltage read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encode bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       reg: The register to read from
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdaux_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Avxr reg,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  auxiliary voltages
+ *
+ * \warning         The \c out array should be large enough to store
+ *                  \c LTC6810_2_REG_AUX_COUNT voltages for each IC in the chain
+ *
+ * \details         Auxiliary voltages are 16-bit values represented in mV * 10
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the auxiliary voltages are stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdaux_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint16_t *out);
+
+/*!
+ * \brief           Encode the broadcast status read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the correct
+ *                  size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       reg: The register to read from
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Stxr reg,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  status data
+ *
+ * \warning         The \c out array should be as large as the total number of
+ *                  ICs in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       reg: The register where the data comes from
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the status data is stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdstat_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Stxr reg,
+    const uint8_t *payload,
+    struct Ltc68102Str *out);
+
+/*!
+ * \brief           Encode S pin control data of the ICs into a broadcast
+ *                  write command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \warning         The \c data array size MUST be equal to the number of S pin
+ *                  control values of all the ICs in the chain
+ *                  (i.e. \c LTC6810_2_SCTRL_COUNT * \c handler.count)
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of data to write
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ */
+size_t ltc6810_2_wrsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast S pin control read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encode bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  S pin control data
+ *
+ * \warning         The \c out array should be large enough to store
+ *                  \c LTC6810_2_SCTL_COUNT values for each IC in the chain
+ *
+ * \details         S pin control bits are represented as 4 bits values that
+ *                  controls the behaviors of the S pins
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the S pin control data is stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdsctrl_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast start S pin control pulsing and poll
+ *                  status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_stsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broacast clear S pin control register command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_clrsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode PWM data of the ICs into a broadcast write command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \warning         The \c data array size MUST be equal to the total number of
+ *                  PWM values of all the ICs in the chain
+ *                  (i.e. \c LTC6810_2_PWM_COUNT * \c chain.count)
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of data to write
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ */
+size_t ltc6810_2_wrpwm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast PWM read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encode bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdpwm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast read command response payload into
+ *                  PWM data
+ *
+ * \warning         The \c out array should be large enough to store
+ *                  \c LTC6810_2_PWM_COUNT values for each IC in the chain
+ *
+ * \details         PWM values are 4-bit integers that represent a specific
+ *                  duty cycle from 0 = 0% to 15 = 100%
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the pwm data is stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdpwm_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast cells ADC conversion start and poll
+ *                  status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       dcp: Allow (or not) measurements during discharge
+ * \param[in]       cells: The selected cells to measure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adcv_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    enum Ltc68102Ch cells,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast Open Wire ADC conversion start and
+ *                  poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       pup: Set Pull-up or Pull-down current
+ * \param[in]       dcp: Allow (or not) measurement during discharge
+ * \param[in]       cells: The selected cells to measure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adow_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Pup pup,
+    enum Ltc68102Dcp dcp,
+    enum Ltc68102Ch cells,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast cell voltage conversion self test
+ *                  start and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       test_mode: Self test mode option
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_cvst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast cell 7 voltage overlap measurement
+ *                  start command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       dcp: Allow (or not) measurement during discharge
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adol_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast GPIOs ADC conversion start and poll
+ *                  status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the correct
+ *                  size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       gpios: The selected GPIOs
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adax_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast GPIOs ADC conversion with digital
+ *                  redundancy start and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       gpios: The selected GPIOs
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adaxd_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast GPIOs conversion self test start and
+ *                  poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       test_mode: Self test mode option
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_axst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast status group ADC conversion start and
+ *                  poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       group: The selected status group
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chst group,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast status group ADC conversion with
+ *                  digital redundancy start and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       groups: The selected status group
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adstatd_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chst groups,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast status group conversion self test
+ *                  start and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       test_mode: Self test mode option
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_statst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast cell voltage and GPIOs ADC conversion
+ *                  start and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       dcp: Allow (or not) measurement during discharge
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adcvax_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast cell voltage and SC conversion start
+ *                  and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       dcp: Allow (or not) measurement during discharge
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_adcvsc_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast clear cell voltage register command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_clrcell_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast clear GPIOs voltage register command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_clraux_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast clear status register command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_clrstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast poll ADC conversion status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \warning         Do not pull the Chip Select(CS) high before the conversion
+ *                  has ended otherwise this command will not work
+ *
+ * \details         To check if the ADC conversion has ended, after sending
+ *                  the encoded command, read a single byte and check its status
+ *                  using the \c ltc6810_2_pladc_is_completed function until it has
+ *                  ended conversion
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_pladc_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast diagnose MUX and poll status command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  right size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_diagn_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the external communication data of the ICs into a
+ *                  broadcast write command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \warning         The \c comm array size MUST be equals to the number of ICs
+ *                  in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       comms: The communication data to write
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ */
+size_t ltc6810_2_wrcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    struct Ltc68102Comm *comms,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the external communication data of the ICs into a
+ *                  broadcast read command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the correct
+ *                  size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast external communication payload
+ *
+ * \warning         The \c out array should be as large as the total number of
+ *                  ICs in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the communication data is stored
+ * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_rdcomm_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    struct Ltc68102Comm *out);
+
+/*!
+ * \brief           Encode the external communication broadcast start command
+ *
+ * \warning         The \c out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the \c LTC6810_2_STCOMM_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to \c LTC6810_2_STCOMM_BUFFER_SIZE
+ */
+size_t ltc6810_2_stcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+#endif // LTC6810_2_API_H

--- a/include/drivers/ltc6810-2/ltc6810-2-api.h
+++ b/include/drivers/ltc6810-2/ltc6810-2-api.h
@@ -19,6 +19,16 @@
 #include "ltc6810-2.h"
 
 /*!
+ * \brief           Extract cell x (1..6) undervoltage flag from Ltc68102Str.cell_flags
+ */
+#define LTC6810_2_API_STR_CUV(str, x) (((str).cell_flags >> (2U * ((x) - 1U))) & 0x1U)
+/*!
+ * \brief           Extract cell x (1..6) overvoltage flag from Ltc68102Str.cell_flags
+ */
+#define LTC6810_2_API_STR_COV(str, x) (((str).cell_flags >> (2U * ((x) - 1U) + 1U)) & 0x1U)
+
+
+/*!
  * \brief           Initialize the IC handler structure
  *
  * \param[in]       handler: The IC handler structure

--- a/include/drivers/ltc6810-2/ltc6810-2-api.h
+++ b/include/drivers/ltc6810-2/ltc6810-2-api.h
@@ -46,7 +46,7 @@ void ltc6810_2_api_init(struct Ltc68102Handler *handler, size_t ltc_count);
  *                  has ended otherwise this command will not work
  *
  * \param[in]       byte: A byte read after the pladc command was sent
- * \return          True if the conversion has ended, false otherwise
+ * \returns         bool True if the conversion has ended, false otherwise
  */
 bool ltc6810_2_api_pladc_is_completed(const uint8_t byte);
 
@@ -65,7 +65,7 @@ bool ltc6810_2_api_pladc_is_completed(const uint8_t byte);
  * \param[in]       handler: The IC handler structure
  * \param[in]       config: The configuration data array
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
 size_t ltc6810_2_api_wrcfg_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -82,7 +82,7 @@ size_t ltc6810_2_api_wrcfg_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcfg_encode_broadcast(const struct Ltc68102Handler *handler, uint8_t *out);
 
@@ -96,7 +96,7 @@ size_t ltc6810_2_api_rdcfg_encode_broadcast(const struct Ltc68102Handler *handle
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the configuration data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcfg_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -114,7 +114,7 @@ size_t ltc6810_2_api_rdcfg_decode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         szie_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcv_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -134,7 +134,7 @@ size_t ltc6810_2_api_rdcv_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the cell voltages are stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcv_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -152,7 +152,7 @@ size_t ltc6810_2_api_rdcv_decode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdaux_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -171,7 +171,7 @@ size_t ltc6810_2_api_rdaux_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the auxiliary voltages are stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdaux_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -189,7 +189,7 @@ size_t ltc6810_2_api_rdaux_decode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -207,7 +207,7 @@ size_t ltc6810_2_api_rdstat_encode_broadcast(
  * \param[in]       reg: The register where the data comes from
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the status data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdstat_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -231,7 +231,7 @@ size_t ltc6810_2_api_rdstat_decode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
 size_t ltc6810_2_api_wrsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -248,7 +248,7 @@ size_t ltc6810_2_api_wrsctrl_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -267,7 +267,7 @@ size_t ltc6810_2_api_rdsctrl_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the S pin control data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdsctrl_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -285,7 +285,7 @@ size_t ltc6810_2_api_rdsctrl_decode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_stsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -301,7 +301,7 @@ size_t ltc6810_2_api_stsctrl_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_clrsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -322,7 +322,7 @@ size_t ltc6810_2_api_clrsctrl_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
 size_t ltc6810_2_api_wrpwm_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -339,7 +339,7 @@ size_t ltc6810_2_api_wrpwm_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdpwm_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -358,7 +358,7 @@ size_t ltc6810_2_api_rdpwm_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the pwm data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdpwm_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -379,7 +379,7 @@ size_t ltc6810_2_api_rdpwm_decode_broadcast(
  * \param[in]       dcp: Allow (or not) measurements during discharge
  * \param[in]       cells: The selected cells to measure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adcv_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -403,7 +403,7 @@ size_t ltc6810_2_api_adcv_encode_broadcast(
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[in]       cells: The selected cells to measure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adow_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -426,7 +426,7 @@ size_t ltc6810_2_api_adow_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_cvst_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -447,7 +447,7 @@ size_t ltc6810_2_api_cvst_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adol_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -468,7 +468,7 @@ size_t ltc6810_2_api_adol_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       gpios: The selected GPIOs
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adax_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -489,7 +489,7 @@ size_t ltc6810_2_api_adax_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       gpios: The selected GPIOs
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adaxd_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -510,7 +510,7 @@ size_t ltc6810_2_api_adaxd_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_axst_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -531,7 +531,7 @@ size_t ltc6810_2_api_axst_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       group: The selected status group
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -552,7 +552,7 @@ size_t ltc6810_2_api_adstat_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       groups: The selected status group
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adstatd_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -573,7 +573,7 @@ size_t ltc6810_2_api_adstatd_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_statst_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -594,7 +594,7 @@ size_t ltc6810_2_api_statst_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adcvax_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -615,7 +615,7 @@ size_t ltc6810_2_api_adcvax_encode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_adcvsc_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -633,7 +633,7 @@ size_t ltc6810_2_api_adcvsc_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_clrcell_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -649,7 +649,7 @@ size_t ltc6810_2_api_clrcell_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_clraux_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -665,7 +665,7 @@ size_t ltc6810_2_api_clraux_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_clrstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -689,7 +689,7 @@ size_t ltc6810_2_api_clrstat_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_pladc_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -705,7 +705,7 @@ size_t ltc6810_2_api_pladc_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_diagn_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -726,7 +726,7 @@ size_t ltc6810_2_api_diagn_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       comms: The communication data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
 size_t ltc6810_2_api_wrcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -744,7 +744,7 @@ size_t ltc6810_2_api_wrcomm_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -759,7 +759,7 @@ size_t ltc6810_2_api_rdcomm_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the communication data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdcomm_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -776,7 +776,7 @@ size_t ltc6810_2_api_rdcomm_decode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_STCOMM_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_STCOMM_BUFFER_SIZE
  */
 size_t ltc6810_2_api_stcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -792,7 +792,7 @@ size_t ltc6810_2_api_stcomm_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_mute_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -808,7 +808,7 @@ size_t ltc6810_2_api_mute_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_unmute_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -824,7 +824,7 @@ size_t ltc6810_2_api_unmute_encode_broadcast(
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdsid_encode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -839,7 +839,7 @@ size_t ltc6810_2_api_rdsid_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the serial ID bytes are stored
- * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ * \returns         size_t The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
 size_t ltc6810_2_api_rdsid_decode_broadcast(
     const struct Ltc68102Handler *handler,
@@ -859,7 +859,7 @@ size_t ltc6810_2_api_rdsid_decode_broadcast(
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       gpios: The selected GPIOs
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ * \returns         size_t The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
 size_t ltc6810_2_api_axow_encode_broadcast(
     const struct Ltc68102Handler *handler,

--- a/include/drivers/ltc6810-2/ltc6810-2-api.h
+++ b/include/drivers/ltc6810-2/ltc6810-2-api.h
@@ -9,23 +9,26 @@
  * \link            https://www.analog.com/media/en/technical-documentation/data-sheets/ltc6810-1-6810-2.pdf
 */
 
-#ifndef LTC6810_2_API_H
-#define LTC6810_2_API_H
+#ifndef ltc6810_2_API_H
+#define ltc6810_2_API_H
 
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "ltc6810-2.h"
+#include "eagletrt-api.h"
 
 /*!
  * \brief           Extract cell x (1..6) undervoltage flag from Ltc68102Str.cell_flags
  */
-#define LTC6810_2_API_STR_CUV(str, x) (((str).cell_flags >> (2U * ((x) - 1U))) & 0x1U)
+#define LTC6810_2_API_STR_CUV(str, x) (EAGLETRT_API_BIT_GET((str).cell_flags, (2U * ((x) -1U))))
 /*!
  * \brief           Extract cell x (1..6) overvoltage flag from Ltc68102Str.cell_flags
  */
-#define LTC6810_2_API_STR_COV(str, x) (((str).cell_flags >> (2U * ((x) - 1U) + 1U)) & 0x1U)
+#define LTC6810_2_API_STR_COV(str, x) (EAGLETRT_API_BIT_GET((str).cell_flags, (2U * ((x) - 1U) + 1U)))
+
+
 
 
 /*!
@@ -34,7 +37,7 @@
  * \param[in]       handler: The IC handler structure
  * \param[in]       ltc_count: The total number of ICs in the chain
  */
-void ltc6810_2_init(struct Ltc68102Handler *handler, size_t ltc_count);
+void ltc6810_2_api_init(struct Ltc68102Handler *handler, size_t ltc_count);
 
 /*!
  * \brief           Check if the ADC conversion has ended or not
@@ -45,26 +48,26 @@ void ltc6810_2_init(struct Ltc68102Handler *handler, size_t ltc_count);
  * \param[in]       byte: A byte read after the pladc command was sent
  * \return          True if the conversion has ended, false otherwise
  */
-bool ltc6810_2_pladc_is_completed(const uint8_t byte);
+bool ltc6810_2_api_pladc_is_completed(const uint8_t byte);
 
 /*!
  * \brief           Encode the configuration data of the ICs into a broadcast
  *                  write command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_WRITE_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
- * \warning         The \c config array size MUST be equal to the number of ICs
+ * \warning         The config array size MUST be equal to the number of ICs
  *                  in the chain
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       config: The configuration data array
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
-size_t ltc6810_2_wrcfg_encode_broadcast(
+size_t ltc6810_2_api_wrcfg_encode_broadcast(
     const struct Ltc68102Handler *handler,
     struct Ltc68102Cfgr *config,
     uint8_t *out);
@@ -72,30 +75,30 @@ size_t ltc6810_2_wrcfg_encode_broadcast(
 /*!
  * \brief           Encode the broadcast configuration read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcfg_encode_broadcast(const struct Ltc68102Handler *handler, uint8_t *out);
+size_t ltc6810_2_api_rdcfg_encode_broadcast(const struct Ltc68102Handler *handler, uint8_t *out);
 
 /*!
  * \brief           Decode the ICs broadcast read command response payload into
  *                  configuration data
  *
- * \warning         The \c out array should be as large as the total number of
+ * \warning         The out array should be as large as the total number of
  *                  ICs in the chain
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the configuration data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcfg_decode_broadcast(
+size_t ltc6810_2_api_rdcfg_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     struct Ltc68102Cfgr *out);
@@ -103,17 +106,17 @@ size_t ltc6810_2_rdcfg_decode_broadcast(
 /*!
  * \brief           Encode the broadcast cell voltage read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encode bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcv_encode_broadcast(
+size_t ltc6810_2_api_rdcv_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Cvxr reg,
     uint8_t *out);
@@ -122,8 +125,8 @@ size_t ltc6810_2_rdcv_encode_broadcast(
  * \brief           Decode the ICs broadcast read command response payload into
  *                  cell voltages
  *
- * \warning         The \c out array should be large enough to store
- *                  \c LTC6810_2_REG_CELL_COUNT voltages for each IC in the
+ * \warning         The out array should be large enough to store
+ *                  LTC6810_2_REG_CELL_COUNT voltages for each IC in the
  *                  chain
  *
  * \details         Cell voltages are 16-bit values represented in mV * 10
@@ -131,9 +134,9 @@ size_t ltc6810_2_rdcv_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the cell voltages are stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcv_decode_broadcast(
+size_t ltc6810_2_api_rdcv_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint16_t *out);
@@ -141,17 +144,17 @@ size_t ltc6810_2_rdcv_decode_broadcast(
 /*!
  * \brief           Encode the broadcast auxiliary voltage read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encode bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdaux_encode_broadcast(
+size_t ltc6810_2_api_rdaux_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Avxr reg,
     uint8_t *out);
@@ -160,17 +163,17 @@ size_t ltc6810_2_rdaux_encode_broadcast(
  * \brief           Decode the ICs broadcast read command response payload into
  *                  auxiliary voltages
  *
- * \warning         The \c out array should be large enough to store
- *                  \c LTC6810_2_REG_AUX_COUNT voltages for each IC in the chain
+ * \warning         The out array should be large enough to store
+ *                  LTC6810_2_REG_AUX_COUNT voltages for each IC in the chain
  *
  * \details         Auxiliary voltages are 16-bit values represented in mV * 10
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the auxiliary voltages are stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdaux_decode_broadcast(
+size_t ltc6810_2_api_rdaux_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint16_t *out);
@@ -178,17 +181,17 @@ size_t ltc6810_2_rdaux_decode_broadcast(
 /*!
  * \brief           Encode the broadcast status read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the correct
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the correct
  *                  size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register to read from
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdstat_encode_broadcast(
+size_t ltc6810_2_api_rdstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Stxr reg,
     uint8_t *out);
@@ -197,16 +200,16 @@ size_t ltc6810_2_rdstat_encode_broadcast(
  * \brief           Decode the ICs broadcast read command response payload into
  *                  status data
  *
- * \warning         The \c out array should be as large as the total number of
+ * \warning         The out array should be as large as the total number of
  *                  ICs in the chain
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       reg: The register where the data comes from
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the status data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdstat_decode_broadcast(
+size_t ltc6810_2_api_rdstat_decode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Stxr reg,
     const uint8_t *payload,
@@ -216,21 +219,21 @@ size_t ltc6810_2_rdstat_decode_broadcast(
  * \brief           Encode S pin control data of the ICs into a broadcast
  *                  write command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_WRITE_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
- * \warning         The \c data array size MUST be equal to the number of S pin
+ * \warning         The data array size MUST be equal to the number of S pin
  *                  control values of all the ICs in the chain
- *                  (i.e. \c LTC6810_2_SCTRL_COUNT * \c handler.count)
+ *                  (i.e. LTC6810_2_SCTRL_COUNT * handler.count)
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
-size_t ltc6810_2_wrsctrl_encode_broadcast(
+size_t ltc6810_2_api_wrsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint8_t *out);
@@ -238,16 +241,16 @@ size_t ltc6810_2_wrsctrl_encode_broadcast(
 /*!
  * \brief           Encode the broadcast S pin control read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encode bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdsctrl_encode_broadcast(
+size_t ltc6810_2_api_rdsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
@@ -255,8 +258,8 @@ size_t ltc6810_2_rdsctrl_encode_broadcast(
  * \brief           Decode the ICs broadcast read command response payload into
  *                  S pin control data
  *
- * \warning         The \c out array should be large enough to store
- *                  \c LTC6810_2_SCTL_COUNT values for each IC in the chain
+ * \warning         The out array should be large enough to store
+ *                  LTC6810_2_SCTL_COUNT values for each IC in the chain
  *
  * \details         S pin control bits are represented as 4 bits values that
  *                  controls the behaviors of the S pins
@@ -264,9 +267,9 @@ size_t ltc6810_2_rdsctrl_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the S pin control data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdsctrl_decode_broadcast(
+size_t ltc6810_2_api_rdsctrl_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint8_t *out);
@@ -275,53 +278,53 @@ size_t ltc6810_2_rdsctrl_decode_broadcast(
  * \brief           Encode the broadcast start S pin control pulsing and poll
  *                  status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_stsctrl_encode_broadcast(
+size_t ltc6810_2_api_stsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode the broacast clear S pin control register command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_clrsctrl_encode_broadcast(
+size_t ltc6810_2_api_clrsctrl_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode PWM data of the ICs into a broadcast write command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_WRITE_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
- * \warning         The \c data array size MUST be equal to the total number of
+ * \warning         The data array size MUST be equal to the total number of
  *                  PWM values of all the ICs in the chain
- *                  (i.e. \c LTC6810_2_PWM_COUNT * \c chain.count)
+ *                  (i.e. LTC6810_2_PWM_COUNT * chain.count)
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
-size_t ltc6810_2_wrpwm_encode_broadcast(
+size_t ltc6810_2_api_wrpwm_encode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint8_t *out);
@@ -329,16 +332,16 @@ size_t ltc6810_2_wrpwm_encode_broadcast(
 /*!
  * \brief           Encode the broadcast PWM read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encode bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdpwm_encode_broadcast(
+size_t ltc6810_2_api_rdpwm_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
@@ -346,8 +349,8 @@ size_t ltc6810_2_rdpwm_encode_broadcast(
  * \brief           Decode the ICs broadcast read command response payload into
  *                  PWM data
  *
- * \warning         The \c out array should be large enough to store
- *                  \c LTC6810_2_PWM_COUNT values for each IC in the chain
+ * \warning         The out array should be large enough to store
+ *                  LTC6810_2_PWM_COUNT values for each IC in the chain
  *
  * \details         PWM values are 4-bit integers that represent a specific
  *                  duty cycle from 0 = 0% to 15 = 100%
@@ -355,9 +358,9 @@ size_t ltc6810_2_rdpwm_encode_broadcast(
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the pwm data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdpwm_decode_broadcast(
+size_t ltc6810_2_api_rdpwm_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     uint8_t *out);
@@ -366,9 +369,9 @@ size_t ltc6810_2_rdpwm_decode_broadcast(
  * \brief           Encode the broadcast cells ADC conversion start and poll
  *                  status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
@@ -376,9 +379,9 @@ size_t ltc6810_2_rdpwm_decode_broadcast(
  * \param[in]       dcp: Allow (or not) measurements during discharge
  * \param[in]       cells: The selected cells to measure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adcv_encode_broadcast(
+size_t ltc6810_2_api_adcv_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Dcp dcp,
@@ -389,9 +392,9 @@ size_t ltc6810_2_adcv_encode_broadcast(
  * \brief           Encode the broadcast Open Wire ADC conversion start and
  *                  poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
@@ -400,9 +403,9 @@ size_t ltc6810_2_adcv_encode_broadcast(
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[in]       cells: The selected cells to measure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adow_encode_broadcast(
+size_t ltc6810_2_api_adow_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Pup pup,
@@ -414,18 +417,18 @@ size_t ltc6810_2_adow_encode_broadcast(
  * \brief           Encode the broadcast cell voltage conversion self test
  *                  start and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_cvst_encode_broadcast(
+size_t ltc6810_2_api_cvst_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102St test_mode,
@@ -435,18 +438,18 @@ size_t ltc6810_2_cvst_encode_broadcast(
  * \brief           Encode the broadcast cell 7 voltage overlap measurement
  *                  start command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adol_encode_broadcast(
+size_t ltc6810_2_api_adol_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Dcp dcp,
@@ -456,18 +459,18 @@ size_t ltc6810_2_adol_encode_broadcast(
  * \brief           Encode the broadcast GPIOs ADC conversion start and poll
  *                  status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the correct
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the correct
  *                  size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       gpios: The selected GPIOs
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adax_encode_broadcast(
+size_t ltc6810_2_api_adax_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Chg gpios,
@@ -477,18 +480,18 @@ size_t ltc6810_2_adax_encode_broadcast(
  * \brief           Encode the broadcast GPIOs ADC conversion with digital
  *                  redundancy start and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       gpios: The selected GPIOs
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adaxd_encode_broadcast(
+size_t ltc6810_2_api_adaxd_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Chg gpios,
@@ -498,18 +501,18 @@ size_t ltc6810_2_adaxd_encode_broadcast(
  * \brief           Encode the broadcast GPIOs conversion self test start and
  *                  poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_axst_encode_broadcast(
+size_t ltc6810_2_api_axst_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102St test_mode,
@@ -519,18 +522,18 @@ size_t ltc6810_2_axst_encode_broadcast(
  * \brief           Encode the broadcast status group ADC conversion start and
  *                  poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       group: The selected status group
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adstat_encode_broadcast(
+size_t ltc6810_2_api_adstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Chst group,
@@ -540,18 +543,18 @@ size_t ltc6810_2_adstat_encode_broadcast(
  * \brief           Encode the broadcast status group ADC conversion with
  *                  digital redundancy start and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       groups: The selected status group
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adstatd_encode_broadcast(
+size_t ltc6810_2_api_adstatd_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Chst groups,
@@ -561,18 +564,18 @@ size_t ltc6810_2_adstatd_encode_broadcast(
  * \brief           Encode the broadcast status group conversion self test
  *                  start and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       test_mode: Self test mode option
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_statst_encode_broadcast(
+size_t ltc6810_2_api_statst_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102St test_mode,
@@ -582,18 +585,18 @@ size_t ltc6810_2_statst_encode_broadcast(
  * \brief           Encode the broadcast cell voltage and GPIOs ADC conversion
  *                  start and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adcvax_encode_broadcast(
+size_t ltc6810_2_api_adcvax_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Dcp dcp,
@@ -603,18 +606,18 @@ size_t ltc6810_2_adcvax_encode_broadcast(
  * \brief           Encode the broadcast cell voltage and SC conversion start
  *                  and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       mode: The selected ADC conversion mode
  * \param[in]       dcp: Allow (or not) measurement during discharge
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_adcvsc_encode_broadcast(
+size_t ltc6810_2_api_adcvsc_encode_broadcast(
     const struct Ltc68102Handler *handler,
     enum Ltc68102Md mode,
     enum Ltc68102Dcp dcp,
@@ -623,57 +626,57 @@ size_t ltc6810_2_adcvsc_encode_broadcast(
 /*!
  * \brief           Encode the broadcast clear cell voltage register command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_clrcell_encode_broadcast(
+size_t ltc6810_2_api_clrcell_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode the broadcast clear GPIOs voltage register command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_clraux_encode_broadcast(
+size_t ltc6810_2_api_clraux_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode the broadcast clear status register command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_clrstat_encode_broadcast(
+size_t ltc6810_2_api_clrstat_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode the broadcast poll ADC conversion status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \warning         Do not pull the Chip Select(CS) high before the conversion
@@ -681,30 +684,30 @@ size_t ltc6810_2_clrstat_encode_broadcast(
  *
  * \details         To check if the ADC conversion has ended, after sending
  *                  the encoded command, read a single byte and check its status
- *                  using the \c ltc6810_2_pladc_is_completed function until it has
+ *                  using the LTC6810_2_pladc_is_completed function until it has
  *                  ended conversion
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_pladc_encode_broadcast(
+size_t ltc6810_2_api_pladc_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Encode the broadcast diagnose MUX and poll status command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
  *                  right size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_POLL_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
  */
-size_t ltc6810_2_diagn_encode_broadcast(
+size_t ltc6810_2_api_diagn_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
@@ -712,20 +715,20 @@ size_t ltc6810_2_diagn_encode_broadcast(
  * \brief           Encode the external communication data of the ICs into a
  *                  broadcast write command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_WRITE_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_WRITE_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
- * \warning         The \c comm array size MUST be equals to the number of ICs
+ * \warning         The comm array size MUST be equals to the number of ICs
  *                  in the chain
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       comms: The communication data to write
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_WRITE_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_WRITE_BUFFER_SIZE
  */
-size_t ltc6810_2_wrcomm_encode_broadcast(
+size_t ltc6810_2_api_wrcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
     struct Ltc68102Comm *comms,
     uint8_t *out);
@@ -734,31 +737,31 @@ size_t ltc6810_2_wrcomm_encode_broadcast(
  * \brief           Encode the external communication data of the ICs into a
  *                  broadcast read command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_READ_BUFFER_SIZE macro to get the correct
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the correct
  *                  size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_READ_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcomm_encode_broadcast(
+size_t ltc6810_2_api_rdcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
     uint8_t *out);
 
 /*!
  * \brief           Decode the ICs broadcast external communication payload
  *
- * \warning         The \c out array should be as large as the total number of
+ * \warning         The out array should be as large as the total number of
  *                  ICs in the chain
  *
  * \param[in]       handler: The IC handler structure
  * \param[in]       payload: The array of bytes to decode
  * \param[out]      out: The array where the communication data is stored
- * \return          The number of decoded bytes (PEC included), should be equal to \c LTC6810_2_DATA_BUFFER_SIZE
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
  */
-size_t ltc6810_2_rdcomm_decode_broadcast(
+size_t ltc6810_2_api_rdcomm_decode_broadcast(
     const struct Ltc68102Handler *handler,
     const uint8_t *payload,
     struct Ltc68102Comm *out);
@@ -766,17 +769,102 @@ size_t ltc6810_2_rdcomm_decode_broadcast(
 /*!
  * \brief           Encode the external communication broadcast start command
  *
- * \warning         The \c out array should be large enough to contain all the
+ * \warning         The out array should be large enough to contain all the
  *                  encoded bytes.
- *                  Use the \c LTC6810_2_STCOMM_BUFFER_SIZE macro to get the
+ *                  Use the LTC6810_2_STCOMM_BUFFER_SIZE macro to get the
  *                  correct size for the buffer
  *
  * \param[in]       handler: The IC handler structure
  * \param[out]      out: The array where the encoded bytes are written
- * \return          The number of encoded bytes, should be equal to \c LTC6810_2_STCOMM_BUFFER_SIZE
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_STCOMM_BUFFER_SIZE
  */
-size_t ltc6810_2_stcomm_encode_broadcast(
+size_t ltc6810_2_api_stcomm_encode_broadcast(
     const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast mute all S-pin discharge command
+ *
+ * \warning         The out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_api_mute_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast unmute S-pin discharge command
+ *
+ * \warning         The out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_api_unmute_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast serial ID read command
+ *
+ * \warning         The out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the LTC6810_2_READ_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_READ_BUFFER_SIZE
+ */
+size_t ltc6810_2_api_rdsid_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out);
+
+/*!
+ * \brief           Decode the ICs broadcast serial ID read payload
+ *
+ * \warning         The out array should be large enough to store
+ *                  LTC6810_2_REG_BYTE_COUNT bytes for each IC in the chain
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       payload: The array of bytes to decode
+ * \param[out]      out: The array where the serial ID bytes are stored
+ * \return          The number of decoded bytes (PEC included), should be equal to LTC6810_2_DATA_BUFFER_SIZE
+ */
+size_t ltc6810_2_api_rdsid_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out);
+
+/*!
+ * \brief           Encode the broadcast GPIOs ADC open wire conversion start
+ *                  and poll status command
+ *
+ * \warning         The out array should be large enough to contain all the
+ *                  encoded bytes.
+ *                  Use the LTC6810_2_POLL_BUFFER_SIZE macro to get the
+ *                  correct size for the buffer
+ *
+ * \param[in]       handler: The IC handler structure
+ * \param[in]       mode: The selected ADC conversion mode
+ * \param[in]       gpios: The selected GPIOs
+ * \param[out]      out: The array where the encoded bytes are written
+ * \return          The number of encoded bytes, should be equal to LTC6810_2_POLL_BUFFER_SIZE
+ */
+size_t ltc6810_2_api_axow_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
     uint8_t *out);
 
 #endif // LTC6810_2_API_H

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -533,7 +533,7 @@ struct Ltc68102Comm {
  * \brief           LTC6810-2 handler structure
  */
 struct Ltc68102Handler {
-    size_t count;
+    size_t count; /*!< The number of devices on the bus */
 };
 
 #endif

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -21,8 +21,8 @@
 #define LTC6810_2_PEC_BYTE_COUNT (2U)  /*!< Number of bytes of the PEC */
 #define LTC6810_2_POLL_BYTE_COUNT (1U) /*!< Number of bytes of a single poll response */
 
-#define LTC6810_2_T_IDLE_MS (5U)     /*!< Time required for the isoSPI port to go to the IDLE state in ms */
-#define LTC6810_2_T_SLEEP_MS (2000U) /*!< Time required for the LTC6811 to go the SLEEP state in ms */
+#define LTC6810_2_T_IDLE_MS (6U)     /*!< Time required for the isoSPI port to go to the IDLE state in ms */
+#define LTC6810_2_T_SLEEP_MS (2000U) /*!< Time required for the LTC6810 to go the SLEEP state in ms */
 
 #define LTC6810_2_STCOMM_CYCLES (72U) /*!< Required number of clock cycles for an STCOMM command completion */
 
@@ -53,7 +53,7 @@
  * @{
  */
 
-#define LTC6810_2_REG_SCTRL_COUNT (12U)                                            /*!< Number of S pin control values in a single register (SCTRL[X]) */
+#define LTC6810_2_REG_SCTRL_COUNT (6U)                                             /*!< Number of S pin control values in a single register (SCTRL[X]) */
 #define LTC6810_2_SCTRL_COUNT (LTC6810_2_REG_SCTRL_COUNT * LTC6810_2_SCTRLX_COUNT) /*!< Number of S pin control values in all registers (SCTRL) */
 
 /*! @} */
@@ -63,7 +63,7 @@
  * @{
  */
 
-#define LTC6810_2_REG_PWM_COUNT (12U)                                         /*!< Number of PWM values in a single register (PWM[X]) */
+#define LTC6810_2_REG_PWM_COUNT (6U)                                          /*!< Number of PWM values in a single register (PWM[X]) */
 #define LTC6810_2_PWM_COUNT (LTC6810_2_REG_PWM_COUNT * LTC6810_2_PWMXR_COUNT) /*!< Number of PWM values in all registers (PWM) */
 
 /*! @} */
@@ -119,54 +119,71 @@
 
 /*!
  * \brief           List of available commands for communication with the LTC6810-2
- *
- * \details         Each command maked with (*) is provided for forward-compatibility with LTC6813/6812
  */
 enum Ltc68102Command {
-    LTC6810_2_CMD_WRCFGA = 0b00000000001,   /*!<     Write configuration register group A */
-    LTC6810_2_CMD_WRCFGB = 0b00000100100,   /*!< (*) Write configuration register group B */
-    LTC6810_2_CMD_RDCFGA = 0b00000000010,   /*!<     Read configuration register group A */
-    LTC6810_2_CMD_RDCFGB = 0b00000100110,   /*!< (*) Read configuration register group B */
-    LTC6810_2_CMD_RDCVA = 0b00000000100,    /*!<     Read cell voltage register group A */
-    LTC6810_2_CMD_RDCVB = 0b00000000110,    /*!<     Read cell voltage register group B */
-    LTC6810_2_CMD_RDCVC = 0b00000001000,    /*!<     Read cell voltage register group C */
-    LTC6810_2_CMD_RDCVD = 0b00000001010,    /*!<     Read cell voltage register group D */
-    LTC6810_2_CMD_RDCVE = 0b00000001001,    /*!< (*) Read cell voltage register group E */
-    LTC6810_2_CMD_RDCVF = 0b00000001011,    /*!< (*) Read cell voltage register group F */
-    LTC6810_2_CMD_RDAUXA = 0b00000001100,   /*!<     Read auxiliary register group A */
-    LTC6810_2_CMD_RDAUXB = 0b00000001110,   /*!<     Read auxiliary register group B */
-    LTC6810_2_CMD_RDAUXC = 0b00000001101,   /*!< (*) Read auxiliary register group C */
-    LTC6810_2_CMD_RDAUXD = 0b00000001111,   /*!< (*) Read auxiliary register group D */
-    LTC6810_2_CMD_RDSTATA = 0b00000010000,  /*!<     Read status register group A */
-    LTC6810_2_CMD_RDSTATB = 0b00000010010,  /*!<     Read status register group B */
-    LTC6810_2_CMD_WRSCTRL = 0b00000010100,  /*!<     Write S control register group */
-    LTC6810_2_CMD_WRPWM = 0b00000100000,    /*!<     Write PWM register group */
-    LTC6810_2_CMD_WRPSB = 0b00000011100,    /*!< (*) Write PWM/S control register group B */
-    LTC6810_2_CMD_RDSCTRL = 0b00000010110,  /*!<     Read S control register group */
-    LTC6810_2_CMD_RDPWM = 0b00000100010,    /*!<     Read PWM register group */
-    LTC6810_2_CMD_RDPSB = 0b00000011110,    /*!< (*) Read PWM/S control register group B */
-    LTC6810_2_CMD_STSCTRL = 0b00000011001,  /*!<     Start S control pulsing and poll status */
-    LTC6810_2_CMD_CLRSCTRL = 0b00000011000, /*!<     Clear S control register group */
-    LTC6810_2_CMD_ADCV = 0b01001100000,     /*!<     Start cell voltage ADC conversion and poll status */
-    LTC6810_2_CMD_ADOW = 0b01000101000,     /*!<     Start open wire ADC conversion and poll status */
-    LTC6810_2_CMD_CVST = 0b01000000111,     /*!<     Start self test cell voltage conversion and poll status */
-    LTC6810_2_CMD_ADOL = 0b01000000001,     /*!<     Start overlap measurement of cell 7 voltage */
-    LTC6810_2_CMD_ADAX = 0b10001100000,     /*!<     Start GPIOs ADC conversion and poll status */
-    LTC6810_2_CMD_ADAXD = 0b10000000000,    /*!<     Start GPIOs ADC with digital redundancy and poll status */
-    LTC6810_2_CMD_AXST = 0b10000000111,     /*!<     Start self test GPIOs conversion and poll status */
-    LTC6810_2_CMD_ADSTAT = 0b10001101000,   /*!<     Start status group ADC conversion and poll status */
-    LTC6810_2_CMD_ADSTATD = 0b10000001000,  /*!<     Start status group ADC conversion with digital redundancy and poll status */
-    LTC6810_2_CMD_STATST = 0b10000001111,   /*!<     Start self test status group conversion and poll status */
-    LTC6810_2_CMD_ADCVAX = 0b10001101111,   /*!<     Start combined cell voltage and GPIO1, GPIO2 conversion and poll status */
-    LTC6810_2_CMD_ADCVSC = 0b10001100111,   /*!<     Start combined cell voltage and SC conversion and poll status */
-    LTC6810_2_CMD_CLRCELL = 0b11100010001,  /*!<     Clear cell voltage register groups */
-    LTC6810_2_CMD_CLRAUX = 0b11100010010,   /*!<     Clear auxiliary register groups */
-    LTC6810_2_CMD_CLRSTAT = 0b11100010011,  /*!<     Clear status register groups */
-    LTC6810_2_CMD_PLADC = 0b11100010100,    /*!<     Poll ADC conversion status */
-    LTC6810_2_CMD_DIAGN = 0b11100010101,    /*!<     Diagnose MUX and poll status */
-    LTC6810_2_CMD_WRCOMM = 0b11100100001,   /*!<     Write COMM register group */
-    LTC6810_2_CMD_RDCOMM = 0b11100100010,   /*!<     Read COMM register group */
-    LTC6810_2_CMD_STCOMM = 0b11100100011    /*!<     Start I2C/SPI communication */
+    /*! Configuration Register Commands */
+    LTC6810_2_CMD_WRCFG = 0b00000000001, /*!< Write configuration register group */
+    LTC6810_2_CMD_RDCFG = 0b00000000010, /*!< Read configuration register group */
+
+    /*! Control Register Commands (PWM and S) */
+    LTC6810_2_CMD_WRSCTRL  = 0b00000010100, /*!< Write S control register group */
+    LTC6810_2_CMD_RDSCTRL  = 0b00000010110, /*!< Read S control register group */
+    LTC6810_2_CMD_STSCTRL  = 0b00000011001, /*!< Start S control pulsing and poll status */
+    LTC6810_2_CMD_CLRSCTRL = 0b00000011000, /*!< Clear S control register group */
+    LTC6810_2_CMD_WRPWM = 0b00000100000,   /*!< Write PWM register group */
+    LTC6810_2_CMD_RDPWM = 0b00000100010,   /*!< Read PWM register group */
+
+    /*! Cell Voltage Register Commands (6-cell device only) */
+    LTC6810_2_CMD_RDCVA = 0b00000000100, /*!< Read cell voltage register group A */
+    LTC6810_2_CMD_RDCVB = 0b00000000110, /*!< Read cell voltage register group B */
+
+    /*! S Voltage (Redundant Cell) Register Commands */
+    LTC6810_2_CMD_RDSA = 0b00000001000, /*!< Read S voltage register group A */
+    LTC6810_2_CMD_RDSB = 0b00000001010, /*!< Read S voltage register group B */
+
+    /*! Auxiliary Register Commands (2 groups only) */
+    LTC6810_2_CMD_RDAUXA = 0b00000001100, /*!< Read auxiliary register group A */
+    LTC6810_2_CMD_RDAUXB = 0b00000001110, /*!< Read auxiliary register group B */
+
+    /*! Status Register Commands */
+    LTC6810_2_CMD_RDSTATA = 0b00000010000, /*!< Read status register group A */
+    LTC6810_2_CMD_RDSTATB = 0b00000010010, /*!< Read status register group B */
+
+    /*! Serial ID Register Command */
+    LTC6810_2_CMD_RDSID = 0b00000101100, /*!< Read serial ID register group */
+
+    /*! ADC Conversion Commands */
+    LTC6810_2_CMD_ADCV = 0b01001100000,    /*!< Start cell voltage ADC conversion and poll status */
+    LTC6810_2_CMD_ADOW = 0b01000101000,    /*!< Start open wire ADC conversion and poll status */
+    LTC6810_2_CMD_ADOL = 0b01000000001,    /*!< Start overlap measurement of S voltage for all cells */
+    LTC6810_2_CMD_CVST = 0b01000000111,    /*!< Start self test cell voltage conversion and poll status */
+    LTC6810_2_CMD_ADAX = 0b10001100000,    /*!< Start GPIOs ADC conversion and poll status */
+    LTC6810_2_CMD_ADAXD = 0b10000000000,   /*!< Start GPIOs ADC with digital redundancy and poll status */
+    LTC6810_2_CMD_AXOW = 0b10001010000,    /*!< Start GPIOs ADC open wire conversion and poll status */
+    LTC6810_2_CMD_AXST = 0b10000000111,    /*!< Start self test GPIOs conversion and poll status */
+    LTC6810_2_CMD_ADSTAT = 0b10001101000,  /*!< Start status group ADC conversion and poll status */
+    LTC6810_2_CMD_ADSTATD = 0b10000001000, /*!< Start status group ADC conversion with digital redundancy and poll status */
+    LTC6810_2_CMD_STATST = 0b10000001111,  /*!< Start self test status group conversion and poll status */
+    LTC6810_2_CMD_ADCVAX = 0b10001101111,  /*!< Start combined cell voltage and GPIO1, GPIO2 conversion and poll status */
+    LTC6810_2_CMD_ADCVSC = 0b10001100111,  /*!< Start combined cell voltage and SC conversion and poll status */
+
+    /*! Clear Register Commands */
+    LTC6810_2_CMD_CLRCELL = 0b11100010001, /*!< Clear cell voltage register groups */
+    LTC6810_2_CMD_CLRAUX = 0b11100010010,  /*!< Clear auxiliary register groups */
+    LTC6810_2_CMD_CLRSTAT = 0b11100010011, /*!< Clear status register groups */
+
+    /*! Poll and Diagnostic Commands */
+    LTC6810_2_CMD_PLADC = 0b11100010100, /*!< Poll ADC conversion status */
+    LTC6810_2_CMD_DIAGN = 0b11100010101, /*!< Diagnose MUX and poll status */
+
+    /*! COMM Register Commands (I2C/SPI Master) */
+    LTC6810_2_CMD_WRCOMM = 0b11100100001, /*!< Write COMM register group */
+    LTC6810_2_CMD_RDCOMM = 0b11100100010, /*!< Read COMM register group */
+    LTC6810_2_CMD_STCOMM = 0b11100100011, /*!< Start I2C/SPI communication */
+
+    /*! Discharge Control Commands */
+    LTC6810_2_CMD_MUTE = 0b00000101000,  /*!< Mute discharge */
+    LTC6810_2_CMD_UNMUTE = 0b00000101001 /*!< Unmute discharge */
 };
 
 /*!
@@ -183,8 +200,8 @@ enum Ltc68102Cfgxr {
 enum Ltc68102Cvxr {
     LTC6810_2_CVAR = 0,
     LTC6810_2_CVBR,
-    LTC6810_2_CVCR,
-    LTC6810_2_CVDR,
+    LTC6810_2_CVCR, /*!< Redundant S voltage register group A */
+    LTC6810_2_CVDR, /*!< Redundant S voltage register group B */
     LTC6810_2_CVXR_COUNT
 };
 
@@ -192,17 +209,17 @@ enum Ltc68102Cvxr {
  * \brief           Auxiliary voltage register group names
  */
 enum Ltc68102Avxr {
-    LTC6810_2_AVAR = 0,
-    LTC6810_2_AVBR,
-    LTC6810_2_AVXR_COUNT
+    LTC6810_2_AVAR = 0,  /*!< Auxiliary register group A */
+    LTC6810_2_AVBR,      /*!< Auxiliary register group B */
+    LTC6810_2_AVXR_COUNT /*!< The number of group names */
 };
 
 /*!
  * \brief           Status register group names
  */
 enum Ltc68102Stxr {
-    LTC6810_2_STAR = 0,
-    LTC6810_2_STBR,
+    LTC6810_2_STAR = 0, /*!< Status register group A */
+    LTC6810_2_STBR,     /*!< Status register group B */
     LTC6810_2_STXR_COUNT
 };
 
@@ -210,16 +227,13 @@ enum Ltc68102Stxr {
  * \brief           COMM register group names
  */
 enum Ltc68102Commx {
-    LTC6810_2_COMMA = 0,
+    LTC6810_2_COMM0 = 0,
+    LTC6810_2_COMM1,
+    LTC6810_2_COMM2,
+    LTC6810_2_COMM3,
+    LTC6810_2_COMM4,
+    LTC6810_2_COMM5,
     LTC6810_2_COMMX_COUNT
-};
-
-/*!
- * \brief           S pin control register group names
- */
-enum Ltc68102Sctrlx {
-    LTC6810_2_SCTRLA = 0,
-    LTC6810_2_SCTRLX_COUNT
 };
 
 /*!
@@ -288,13 +302,7 @@ enum Ltc68102Ch {
     LTC6810_2_CH_4,
     LTC6810_2_CH_5,
     LTC6810_2_CH_6,
-    LTC6810_2_CH_7 = LTC6810_2_CH_1,
-    LTC6810_2_CH_8 = LTC6810_2_CH_2,
-    LTC6810_2_CH_9 = LTC6810_2_CH_3,
-    LTC6810_2_CH_10 = LTC6810_2_CH_4,
-    LTC6810_2_CH_11 = LTC6810_2_CH_5,
-    LTC6810_2_CH_12 = LTC6810_2_CH_6,
-    LTC6810_2_CH_COUNT = 7
+    LTC6810_2_CH_COUNT
 };
 
 /*!
@@ -302,11 +310,11 @@ enum Ltc68102Ch {
  */
 enum Ltc68102Chg {
     LTC6810_2_CHG_GPIO_ALL = 0,
+    LTC6810_2_CHG_S0,
     LTC6810_2_CHG_GPIO_1,
     LTC6810_2_CHG_GPIO_2,
     LTC6810_2_CHG_GPIO_3,
     LTC6810_2_CHG_GPIO_4,
-    LTC6810_2_CHG_GPIO_5,
     LTC6810_2_CHG_SECOND_REF, /*!< Second voltage reference */
     LTC6810_2_CHG_COUNT
 };
@@ -389,10 +397,10 @@ enum Ltc68102SpiWfcom {
  * \brief           I2C inital communication control bits on read
  */
 enum Ltc68102I2cRicom {
-    LTC6811_I2C_RICOM_START = 0b0110,     /*!< Master generated a start signal */
-    LTC6811_I2C_RICOM_STOP = 0b0001,      /*!< Master generated a stop signal */
-    LTC6811_I2C_RICOM_BLANK = 0b0000,     /*!< SDA was held low between bytes */
-    LTC6811_I2C_RICOM_NOTRANSMIT = 0b0111 /*!< SDA was held high between bytes */
+    LTC6810_I2C_RICOM_START = 0b0110,     /*!< Master generated a start signal */
+    LTC6810_I2C_RICOM_STOP = 0b0001,      /*!< Master generated a stop signal */
+    LTC6810_I2C_RICOM_BLANK = 0b0000,     /*!< SDA was held low between bytes */
+    LTC6810_I2C_RICOM_NOTRANSMIT = 0b0111 /*!< SDA was held high between bytes */
 };
 
 /*!
@@ -422,57 +430,103 @@ enum Ltc68102SpiRfcom {
 
 /*!
  * \brief           Configuration register group structure
+ *
+ * \details         Layout from datasheet page 64, table 42 (bit 7 ... bit 0):
+ *
+ *                  CFGR0 = [RSVD][GPIO4..GPIO1][REFON][DTEN][ADCOPT]
+ *                  CFGR1 = VUV[7:0]
+ *                  CFGR2 = [VOV[3:0]][VUV[11:8]]
+ *                  CFGR3 = VOV[11:4]
+ *                  CFGR4 = [DCC0][MCAL][DCC6..DCC1]
+ *                  CFGR5 = [DCTO[3:0]][SCONV][FDRF][DIS_RED][DTMEN]
+ *
+ * \note            DCC0 is the 7th discharge control bit (CFGR4[7])
  */
 struct Ltc68102Cfgr {
-    uint8_t ADCOPT : 1; /*!< ADC mode option bit */
-    uint8_t DTEN : 1;   /*!< Discharge timer enable (READ ONLY) */
-    uint8_t REFON : 1;  /*!< References powered up */
-    uint8_t GPIO : 5;   /*!< GPIOx pin control (GPIO1 starts from the least significant bit) */
-    uint16_t VUV : 12;  /*!< Undervoltage comparison voltage */
-    uint16_t VOV : 12;  /*!< Overvoltage comparison voltage */
-    uint16_t DCC : 12;  /*!< Discharge cell x */
-    uint8_t DCTO : 4;   /*!< Discharge time out value */
+    uint8_t ADCOPT : 1;  /*!< CFGR0[0] ADC mode option bit */
+    uint8_t DTEN : 1;    /*!< CFGR0[1] Discharge timer enable (read only) */
+    uint8_t REFON : 1;   /*!< CFGR0[2] References powered up */
+    uint8_t GPIO : 4;    /*!< CFGR0[6:3] GPIO1..GPIO4 pin control */
+    uint8_t RSVD : 1;    /*!< CFGR0[7] Reserved */
+    uint16_t VUV : 12;   /*!< CFGR1 + CFGR2[3:0] Undervoltage comparison voltage */
+    uint16_t VOV : 12;   /*!< CFGR2[7:4] + CFGR3 Overvoltage comparison voltage */
+    uint8_t DCC : 6;     /*!< CFGR4[5:0] Discharge cells 1..6 (DCC1..DCC6) */
+    uint8_t MCAL : 1;    /*!< CFGR4[6] Multi-calibration enable */
+    uint8_t DCC0 : 1;    /*!< CFGR4[7] Discharge 7th cell / S0 (DCC0) */
+    uint8_t DTMEN : 1;   /*!< CFGR5[0] Discharge timer monitor enable */
+    uint8_t DIS_RED : 1; /*!< CFGR5[1] Disable digital redundancy check */
+    uint8_t FDRF : 1;    /*!< CFGR5[2] Force digital redundancy failure */
+    uint8_t SCONV : 1;   /*!< CFGR5[3] Enable cell measurement redundancy via S pins */
+    uint8_t DCTO : 4;    /*!< CFGR5[7:4] Discharge time-out value */
 } __attribute__((__packed__));
 
 /*!
  * \brief           Status register group structure
+ *
+ * \details         Layout from datasheet page 65, tables 47-48 (bit 7 ... bit 0):
+ *
+ *                  STAR0 = SC[7:0]      STAR1 = SC[15:8]
+ *                  STAR2 = ITMP[7:0]    STAR3 = ITMP[15:8]
+ *                  STAR4 = VA[7:0]      STAR5 = VA[15:8]
+ *                  STBR0 = VD[7:0]      STBR1 = VD[15:8]
+ *                  STBR2 = [C4OV][C4UV][C3OV][C3UV][C2OV][C2UV][C1OV][C1UV]
+ *                  STBR3 = [RSVD x3][MUTE][C6OV][C6UV][C5OV][C5UV]
+ *                  STBR4 = RSVD (all bits)
+ *                  STBR5 = [REV[3:0]][RSVD x2][MUXFAIL][THSD]
+ *
+ * \warning         The per-cell OV/UV flags are INTERLEAVED on the wire
+ *                  (C1UV, C1OV, C2UV, C2OV, ...). The cell_flags field below
+ *                  holds the raw 12 bits.
  */
 struct Ltc68102Str {
-    uint16_t SC;         /*!< Sum of all cells measurement */
-    uint16_t ITMP;       /*!< Internal die temperature */
-    uint16_t VA;         /*!< Analog power supply voltage */
-    uint16_t VD;         /*!< Digital power supply voltage */
-    uint16_t COV : 12;   /*!< Cell over voltage flag */
-    uint16_t CUV : 12;   /*!< Cell under voltage flag */
-    uint8_t REV : 4;     /*!< Device revision code */
-    uint8_t RSVD : 2;    /*!< Reserved bits (always 0s) */
-    uint8_t MUXFAIL : 1; /*!< Multiplexer self test result */
-    uint8_t THSD : 1;    /*!< Thermal shutdown status */
+    uint16_t SC;              /*!< STAR0-1 Sum of all cells measurement */
+    uint16_t ITMP;            /*!< STAR2-3 Internal die temperature */
+    uint16_t VA;              /*!< STAR4-5 Analog power supply voltage */
+    uint16_t VD;              /*!< STBR0-1 Digital power supply voltage */
+    uint16_t cell_flags : 12; /*!< STBR2 + STBR3[3:0] interleaved CxUV/CxOV flags */
+    uint16_t MUTE : 1;        /*!< STBR3[4] Discharge mute status */
+    uint16_t RSVD0 : 3;       /*!< STBR3[7:5] Reserved */
+    uint8_t RSVD1;            /*!< STBR4 Reserved */
+    uint8_t THSD : 1;         /*!< STBR5[0] Thermal shutdown status */
+    uint8_t MUXFAIL : 1;      /*!< STBR5[1] Multiplexer self-test result */
+    uint8_t RSVD2 : 2;        /*!< STBR5[3:2] Reserved */
+    uint8_t REV : 4;          /*!< STBR5[7:4] Device revision code */
 } __attribute__((__packed__));
 
 /*!
- * \brief           External communication register group structure
+ * \brief           External communication (COMM) register group structure
  *
- * \details         The IC can be used as master for I2C and SPI communication
- *                  via its GPIOs.
- *                  For I2C:
- *                      - GPIO4 is used as the Serial DAta(SDA)
- *                      - GPIO5 is used as the Serial CLock(SCL)
- *                  For SPI:
- *                      - GPIO3 is used as the Chip Select(CSBM)
- *                      - GPIO4 is used as the Serial Data Input-Output(SDIOM)
- *                      - GPIO5 is used as the Serial Clock(SCKM)
+ * \details         Layout from datasheet page 66, table 51 (bit 7 ... bit 0):
  *
- * \warning         For SPI only mode 3 (CHPA = 1, CPOL = 1) is supported
+ *                  COMM0 = [ICOM0[3:0]][D0[7:4]]
+ *                  COMM1 = [D0[3:0]][FCOM0[3:0]]
+ *                  COMM2 = [ICOM1[3:0]][D1[7:4]]
+ *                  COMM3 = [D1[3:0]][FCOM1[3:0]]
+ *                  COMM4 = [ICOM2[3:0]][D2[7:4]]
+ *                  COMM5 = [D2[3:0]][FCOM2[3:0]]
+ *
+ *                  The IC acts as an I2C or SPI master via its GPIOs.
+ *                  I2C:  GPIO4 = SDA, GPIO5 = SCL
+ *                  SPI:  GPIO3 = CSBM, GPIO4 = SDIOM, GPIO5 = SCKM
+ *
+ * \note            Each data byte Dx is split across two register bytes and
+ *                  interleaved with the ICOMx/FCOMx control nibbles.
+ *
+ * \warning         For SPI, only mode 3 (CPHA = 1, CPOL = 1) is supported.
  */
 struct Ltc68102Comm {
-    uint8_t icom0 : 4;                     /*!< Initial communication control bits of the first data byte */
-    uint8_t icom1 : 4;                     /*!< Initial communication control bits of the second data byte */
-    uint8_t icom2 : 4;                     /*!< Initial communication control bits of the third data byte */
-    uint8_t fcom0 : 4;                     /*!< Final communication control bits of the first data byte */
-    uint8_t fcom1 : 4;                     /*!< Final communication control bits of the second data byte */
-    uint8_t fcom2 : 4;                     /*!< Final communication control bits of the third data byte */
-    uint8_t payload[LTC6810_2_COMM_COUNT]; /*!< Payload data transmited (received) to (from) I2C/SPI slave device */
+    uint8_t D0_hi : 4; /*!< COMM0[3:0] D0[7:4] */
+    uint8_t ICOM0 : 4; /*!< COMM0[7:4] Initial communication control bits of the first data byte */
+    uint8_t FCOM0 : 4; /*!< COMM1[3:0] Final communication control bits of the first data byte */
+    uint8_t D0_lo : 4; /*!< COMM1[7:4] D0[3:0] */
+    uint8_t D1_hi : 4; /*!< COMM2[3:0] D1[7:4] */
+    uint8_t ICOM1 : 4; /*!< COMM2[7:4] Initial communication control bits of the second data byte */
+    uint8_t FCOM1 : 4; /*!< COMM3[3:0] Final communication control bits of the second data byte */
+    uint8_t D1_lo : 4; /*!< COMM3[7:4] D1[3:0] */
+    uint8_t D2_hi : 4; /*!< COMM4[3:0] D2[7:4] */
+    uint8_t ICOM2 : 4; /*!< COMM4[7:4] Initial communication control bits of the third data byte*/
+    uint8_t FCOM2 : 4; /*!< COMM5[3:0] Final communication control bits of the third data byte*/
+    uint8_t D2_lo : 4; /*!< COMM5[7:4] D2[3:0] */
 } __attribute__((__packed__));
 
 /*!

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -1,0 +1,485 @@
+/*!
+ * \file            ltc6810-2.h
+ * \date            2026-5-13
+ * \authors         Mirko Lana [mirko.lana@eagletrt.it]
+ *
+ * \brief           Constants and data structure definitions needed for the
+ *                  LTC6810-2.
+ *
+ * \details         For additional information refer to the datasheet:
+ * \link            https://www.analog.com/media/en/technical-documentation/data-sheets/ltc6810-1-6810-2.pdf
+ */
+
+#ifndef LTC6810_2_H
+#define LTC6810_2_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define LTC6810_2_REG_BYTE_COUNT (6U)  /*!< Number of bytes in a single register */
+#define LTC6810_2_CMD_BYTE_COUNT (2U)  /*!< Number of bytes of a single command (without PEC) */
+#define LTC6810_2_PEC_BYTE_COUNT (2U)  /*!< Number of bytes of the PEC */
+#define LTC6810_2_POLL_BYTE_COUNT (1U) /*!< Number of bytes of a single poll response */
+
+#define LTC6810_2_T_IDLE_MS (5U)     /*!< Time required for the isoSPI port to go to the IDLE state in ms */
+#define LTC6810_2_T_SLEEP_MS (2000U) /*!< Time required for the LTC6811 to go the SLEEP state in ms */
+
+#define LTC6810_2_STCOMM_CYCLES (72U) /*!< Required number of clock cycles for an STCOMM command completion */
+
+#define LTC6810_2_PLADC_COMPLETE_BYTE_VALUE (0xFF)
+
+/*!
+ * \defgroup ltc6810_2_cell_voltage_registers Cell voltage registers definitions
+ * @{
+ */
+
+#define LTC6810_2_REG_CELL_COUNT (3U)                                          /*!< Number of cell voltages in a single register (C[X]V) */
+#define LTC6810_2_CELL_COUNT (LTC6810_2_REG_CELL_COUNT * LTC6810_2_CVXR_COUNT) /*!< Number of cells voltages in all registers (CV) */
+
+/*! @} */
+
+/*!
+ * \defgroup ltc6810_2_aux_voltage_registers Auxiliary voltage registers definitions
+ * @{
+ */
+
+#define LTC6810_2_REG_AUX_COUNT (3U)                                         /*!< Number of auxiliary voltages in a single register (G[X]V) */
+#define LTC6810_2_AUX_COUNT (LTC6810_2_REG_AUX_COUNT * LTC6810_2_AVXR_COUNT) /*!< Number of auxiliary voltages in all registers (GV) */
+
+/*! @} */
+
+/*!
+ * \defgroup ltc6810_2_s_pin_control_registers S pin control registers definitions
+ * @{
+ */
+
+#define LTC6810_2_REG_SCTRL_COUNT (12U)                                            /*!< Number of S pin control values in a single register (SCTRL[X]) */
+#define LTC6810_2_SCTRL_COUNT (LTC6810_2_REG_SCTRL_COUNT * LTC6810_2_SCTRLX_COUNT) /*!< Number of S pin control values in all registers (SCTRL) */
+
+/*! @} */
+
+/*!
+ * \defgroup ltc6810_2_pwm_registers PWM registers definitions
+ * @{
+ */
+
+#define LTC6810_2_REG_PWM_COUNT (12U)                                         /*!< Number of PWM values in a single register (PWM[X]) */
+#define LTC6810_2_PWM_COUNT (LTC6810_2_REG_PWM_COUNT * LTC6810_2_PWMXR_COUNT) /*!< Number of PWM values in all registers (PWM) */
+
+/*! @} */
+
+/*!
+ * \defgroup ltc6810_2_comm_registers COMM registers definitions
+ * @{
+ */
+
+#define LTC6810_2_REG_COMM_COUNT (3U)                                           /*!< Maximum number of bytes that can be written or read from/to a single COMM register (D[X]) */
+#define LTC6810_2_COMM_COUNT (LTC6810_2_REG_COMM_COUNT * LTC6810_2_COMMX_COUNT) /*!< Maximum number of bytes that can be written or read from/to all COMM registers (D) */
+
+/*! @} */
+
+/*!
+ * \brief           Get the buffer size of an encoded write command in bytes
+ *
+ * \details         With multiple ICs the command needs to be sent only once
+ *                  with all the payloads after it
+ *
+ * \param[in]       COUNT: The total number of ICs in the chain
+ * \return          The buffer size in bytes
+ */
+#define LTC6810_2_WRITE_BUFFER_SIZE(COUNT) (                  \
+    (LTC6810_2_CMD_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT) + \
+    ((LTC6810_2_REG_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT)) * (COUNT))
+
+/*!
+ * \brief           Get the buffer size of an encoded read command in bytes
+ */
+#define LTC6810_2_READ_BUFFER_SIZE ((LTC6810_2_CMD_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT))
+
+/*!
+ * \brief           Get the buffer size of the data received from the ICs in bytes
+ *
+ * \param[in]       COUNT: The total number of ICs in the chain
+ * \return          The buffer size in bytes
+ */
+#define LTC6810_2_DATA_BUFFER_SIZE(COUNT) (((LTC6810_2_REG_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT)) * (COUNT))
+
+/*!
+ * \brief           Get the buffer size of an encoded poll command in bytes
+ */
+#define LTC6810_2_POLL_BUFFER_SIZE ((LTC6810_2_CMD_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT))
+
+/*!
+ * \brief           Get the buffer size of an encoded 'STCOMM' command in bytes
+ *
+ * \details         After the STCOMM command it is needed to wait 24 clock cycles
+ *                  for each byte sent to the slave
+ */
+#define LTC6810_2_STCOMM_BUFFER_SIZE ((LTC6810_2_CMD_BYTE_COUNT) + (LTC6810_2_PEC_BYTE_COUNT) + (LTC6810_2_STCOMM_CYCLES))
+
+/*!
+ * \brief           List of available commands for communication with the LTC6810-2
+ *
+ * \details         Each command maked with (*) is provided for forward-compatibility with LTC6813/6812
+ */
+enum Ltc68102Command {
+    LTC6810_2_CMD_WRCFGA = 0b00000000001,   /*!<     Write configuration register group A */
+    LTC6810_2_CMD_WRCFGB = 0b00000100100,   /*!< (*) Write configuration register group B */
+    LTC6810_2_CMD_RDCFGA = 0b00000000010,   /*!<     Read configuration register group A */
+    LTC6810_2_CMD_RDCFGB = 0b00000100110,   /*!< (*) Read configuration register group B */
+    LTC6810_2_CMD_RDCVA = 0b00000000100,    /*!<     Read cell voltage register group A */
+    LTC6810_2_CMD_RDCVB = 0b00000000110,    /*!<     Read cell voltage register group B */
+    LTC6810_2_CMD_RDCVC = 0b00000001000,    /*!<     Read cell voltage register group C */
+    LTC6810_2_CMD_RDCVD = 0b00000001010,    /*!<     Read cell voltage register group D */
+    LTC6810_2_CMD_RDCVE = 0b00000001001,    /*!< (*) Read cell voltage register group E */
+    LTC6810_2_CMD_RDCVF = 0b00000001011,    /*!< (*) Read cell voltage register group F */
+    LTC6810_2_CMD_RDAUXA = 0b00000001100,   /*!<     Read auxiliary register group A */
+    LTC6810_2_CMD_RDAUXB = 0b00000001110,   /*!<     Read auxiliary register group B */
+    LTC6810_2_CMD_RDAUXC = 0b00000001101,   /*!< (*) Read auxiliary register group C */
+    LTC6810_2_CMD_RDAUXD = 0b00000001111,   /*!< (*) Read auxiliary register group D */
+    LTC6810_2_CMD_RDSTATA = 0b00000010000,  /*!<     Read status register group A */
+    LTC6810_2_CMD_RDSTATB = 0b00000010010,  /*!<     Read status register group B */
+    LTC6810_2_CMD_WRSCTRL = 0b00000010100,  /*!<     Write S control register group */
+    LTC6810_2_CMD_WRPWM = 0b00000100000,    /*!<     Write PWM register group */
+    LTC6810_2_CMD_WRPSB = 0b00000011100,    /*!< (*) Write PWM/S control register group B */
+    LTC6810_2_CMD_RDSCTRL = 0b00000010110,  /*!<     Read S control register group */
+    LTC6810_2_CMD_RDPWM = 0b00000100010,    /*!<     Read PWM register group */
+    LTC6810_2_CMD_RDPSB = 0b00000011110,    /*!< (*) Read PWM/S control register group B */
+    LTC6810_2_CMD_STSCTRL = 0b00000011001,  /*!<     Start S control pulsing and poll status */
+    LTC6810_2_CMD_CLRSCTRL = 0b00000011000, /*!<     Clear S control register group */
+    LTC6810_2_CMD_ADCV = 0b01001100000,     /*!<     Start cell voltage ADC conversion and poll status */
+    LTC6810_2_CMD_ADOW = 0b01000101000,     /*!<     Start open wire ADC conversion and poll status */
+    LTC6810_2_CMD_CVST = 0b01000000111,     /*!<     Start self test cell voltage conversion and poll status */
+    LTC6810_2_CMD_ADOL = 0b01000000001,     /*!<     Start overlap measurement of cell 7 voltage */
+    LTC6810_2_CMD_ADAX = 0b10001100000,     /*!<     Start GPIOs ADC conversion and poll status */
+    LTC6810_2_CMD_ADAXD = 0b10000000000,    /*!<     Start GPIOs ADC with digital redundancy and poll status */
+    LTC6810_2_CMD_AXST = 0b10000000111,     /*!<     Start self test GPIOs conversion and poll status */
+    LTC6810_2_CMD_ADSTAT = 0b10001101000,   /*!<     Start status group ADC conversion and poll status */
+    LTC6810_2_CMD_ADSTATD = 0b10000001000,  /*!<     Start status group ADC conversion with digital redundancy and poll status */
+    LTC6810_2_CMD_STATST = 0b10000001111,   /*!<     Start self test status group conversion and poll status */
+    LTC6810_2_CMD_ADCVAX = 0b10001101111,   /*!<     Start combined cell voltage and GPIO1, GPIO2 conversion and poll status */
+    LTC6810_2_CMD_ADCVSC = 0b10001100111,   /*!<     Start combined cell voltage and SC conversion and poll status */
+    LTC6810_2_CMD_CLRCELL = 0b11100010001,  /*!<     Clear cell voltage register groups */
+    LTC6810_2_CMD_CLRAUX = 0b11100010010,   /*!<     Clear auxiliary register groups */
+    LTC6810_2_CMD_CLRSTAT = 0b11100010011,  /*!<     Clear status register groups */
+    LTC6810_2_CMD_PLADC = 0b11100010100,    /*!<     Poll ADC conversion status */
+    LTC6810_2_CMD_DIAGN = 0b11100010101,    /*!<     Diagnose MUX and poll status */
+    LTC6810_2_CMD_WRCOMM = 0b11100100001,   /*!<     Write COMM register group */
+    LTC6810_2_CMD_RDCOMM = 0b11100100010,   /*!<     Read COMM register group */
+    LTC6810_2_CMD_STCOMM = 0b11100100011    /*!<     Start I2C/SPI communication */
+};
+
+/*!
+ * \brief           Configuration register group names
+ */
+enum Ltc68102Cfgxr {
+    LTC6810_2_CFGAR = 0,
+    LTC6810_2_CFGXR_COUNT
+};
+
+/*!
+ * \brief           Cell voltage register group names
+ */
+enum Ltc68102Cvxr {
+    LTC6810_2_CVAR = 0,
+    LTC6810_2_CVBR,
+    LTC6810_2_CVCR,
+    LTC6810_2_CVDR,
+    LTC6810_2_CVXR_COUNT
+};
+
+/*!
+ * \brief           Auxiliary voltage register group names
+ */
+enum Ltc68102Avxr {
+    LTC6810_2_AVAR = 0,
+    LTC6810_2_AVBR,
+    LTC6810_2_AVXR_COUNT
+};
+
+/*!
+ * \brief           Status register group names
+ */
+enum Ltc68102Stxr {
+    LTC6810_2_STAR = 0,
+    LTC6810_2_STBR,
+    LTC6810_2_STXR_COUNT
+};
+
+/*!
+ * \brief           COMM register group names
+ */
+enum Ltc68102Commx {
+    LTC6810_2_COMMA = 0,
+    LTC6810_2_COMMX_COUNT
+};
+
+/*!
+ * \brief           S pin control register group names
+ */
+enum Ltc68102Sctrlx {
+    LTC6810_2_SCTRLA = 0,
+    LTC6810_2_SCTRLX_COUNT
+};
+
+/*!
+ * \brief           PWM register group names
+ */
+enum Ltc68102Pwmxr {
+    LTC6810_2_PWMAR = 0,
+    LTC6810_2_PWMXR_COUNT
+};
+
+/*!
+ * \brief           ADC conversion mode
+ *
+ * \warning         Mode selection depends on ADCOPT flags in the IC
+ *                  configuration register:
+ *                      ADCOPT = 0 -> selects modes 26Hz, 422Hz, 7kHz or 27kHz (default)
+ *                      ADCOPT = 1 -> selects modes 1kHz, 2kHz, 3kHz or 14kHz
+ */
+enum Ltc68102Md {
+    LTC6810_2_MD_422HZ = 0,
+    LTC6810_2_MD_27KHZ,
+    LTC6810_2_MD_7KHZ,
+    LTC6810_2_MD_26HZ,
+    LTC6810_2_MD_1KHZ = LTC6810_2_MD_422HZ,
+    LTC6810_2_MD_14KHZ = LTC6810_2_MD_27KHZ,
+    LTC6810_2_MD_3KHZ = LTC6810_2_MD_7KHZ,
+    LTC6810_2_MD_2KHZ = LTC6810_2_MD_26HZ,
+    LTC6810_2_MD_COUNT = 4
+};
+
+/*!
+ * \brief           Pull-Up/Pull-Down current selection for Open Wire conversions
+ */
+enum Ltc68102Pup {
+    LTC6810_2_PUP_INACTIVE = 0, /*!< Pull-Down current */
+    LTC6810_2_PUP_ACTIVE,       /*!< Pull-Up current */
+    LTC6810_2_PUP_COUNT
+};
+
+/*!
+ * \brief           Self test mode selection
+ */
+enum Ltc68102St {
+    LTC6810_2_ST_ONE = 1,
+    LTC6810_2_ST_TWO,
+    LTC6810_2_ST_COUNT
+};
+
+/*!
+ * \brief           Option to permit or deny measurement during discharge
+ */
+enum Ltc68102Dcp {
+    LTC6810_2_DCP_DISABLED = 0, /*!< Discharge not permitted */
+    LTC6810_2_DCP_ENABLED,      /*!< Discharge permitted */
+    LTC6810_2_DCP_COUNT
+};
+
+/*!
+ * \brief          Cell selection for ADC conversion
+ */
+enum Ltc68102Ch {
+    LTC6810_2_CH_ALL = 0,
+    LTC6810_2_CH_1,
+    LTC6810_2_CH_2,
+    LTC6810_2_CH_3,
+    LTC6810_2_CH_4,
+    LTC6810_2_CH_5,
+    LTC6810_2_CH_6,
+    LTC6810_2_CH_7 = LTC6810_2_CH_1,
+    LTC6810_2_CH_8 = LTC6810_2_CH_2,
+    LTC6810_2_CH_9 = LTC6810_2_CH_3,
+    LTC6810_2_CH_10 = LTC6810_2_CH_4,
+    LTC6810_2_CH_11 = LTC6810_2_CH_5,
+    LTC6810_2_CH_12 = LTC6810_2_CH_6,
+    LTC6810_2_CH_COUNT = 7
+};
+
+/*!
+ * \brief           GPIO selection for ADC conversion
+ */
+enum Ltc68102Chg {
+    LTC6810_2_CHG_GPIO_ALL = 0,
+    LTC6810_2_CHG_GPIO_1,
+    LTC6810_2_CHG_GPIO_2,
+    LTC6810_2_CHG_GPIO_3,
+    LTC6810_2_CHG_GPIO_4,
+    LTC6810_2_CHG_GPIO_5,
+    LTC6810_2_CHG_SECOND_REF, /*!< Second voltage reference */
+    LTC6810_2_CHG_COUNT
+};
+
+/*!
+ * \brief           Status group selection
+ */
+enum Ltc68102Chst {
+    LTC6810_2_CHST_ALL = 0,
+    LTC6810_2_CHST_SC,   /*!< Sum of all cells voltages */
+    LTC6810_2_CHST_ITMP, /*!< Internal Die Temperature */
+    LTC6810_2_CHST_VA,   /*!< Analog power supply */
+    LTC6810_2_CHST_VD,   /*!< Digital power supply */
+    LTC6810_2_CHST_COUNT
+};
+
+/*!
+ * \brief           Discharge timeout selection values
+ */
+enum Ltc68102Dcto {
+    LTC6810_2_DCTO_OFF = 0, /*!< Discharge is disabled */
+    LTC6810_2_DCTO_30S,
+    LTC6810_2_DCTO_1MIN,
+    LTC6810_2_DCTO_2MIN,
+    LTC6810_2_DCTO_3MIN,
+    LTC6810_2_DCTO_4MIN,
+    LTC6810_2_DCTO_5MIN,
+    LTC6810_2_DCTO_10MIN,
+    LTC6810_2_DCTO_15MIN,
+    LTC6810_2_DCTO_20MIN,
+    LTC6810_2_DCTO_30MIN,
+    LTC6810_2_DCTO_40MIN,
+    LTC6810_2_DCTO_60MIN,
+    LTC6810_2_DCTO_75MIN,
+    LTC6810_2_DCTO_90MIN,
+    LTC6810_2_DCTO_120MIN
+};
+
+/*!
+ * \brief           I2C inital communication control bits on write
+ */
+enum Ltc68102I2cWicom {
+    LTC6810_2_I2C_WICOM_START = 0b0110,     /*!< Start signal that will be followed by data */
+    LTC6810_2_I2C_WICOM_STOP = 0b0001,      /*!< Stop signal */
+    LTC6810_2_I2C_WICOM_BLANK = 0b0000,     /*!< Proceed to data trasmission */
+    LTC6810_2_I2C_WICOM_NOTRANSMIT = 0b0111 /*!< Release SDA and SCL and ignore the rest of data */
+};
+
+/*!
+ * \brief           I2C final communication control bits on write
+ */
+enum Ltc68102I2cWfcom {
+    LTC6810_2_I2C_WFCOM_ACK = 0b0000,  /*!< Generate an ACK signal on ninth clock cycle */
+    LTC6810_2_I2C_WFCOM_NACK = 0b1000, /*!< Generate a NACK signal on ninth clock cycle */
+    LTC6810_2_I2C_WFCOM_STOP = 0b1001, /*!< Generate a NACK signal followed by STOP signal */
+};
+
+/*!
+ * \brief           SPI inital communication control bits on write
+ */
+enum Ltc68102SpiWicom {
+    LTC6810_2_SPI_WICOM_LOW = 0b1000,        /*!< Generate a CSBM low signal on SPI port */
+    LTC6810_2_SPI_WICOM_FALLING = 0b1010,    /*!< Drive CSBM high and then low */
+    LTC6810_2_SPI_WICOM_HIGH = 0b1001,       /*!< Generate a CSBM high signal on SPI port */
+    LTC6810_2_SPI_WICOM_NOTRANSMIT = 0b1111, /*!< Release the SPI port and ignore the rest of the data */
+};
+
+/*!
+ * \brief           SPI final communication control bits on write
+ *
+ * \warning         The low value can be either 0b0000 or 0b1000
+ */
+enum Ltc68102SpiWfcom {
+    LTC6810_2_SPI_WFCOM_LOW = 0b0000,   /*!< Holds CSBM low at the end of byte transmission */
+    LTC6810_2_SPI_WFCOM_LOW_B = 0b1000, /*!< Holds CSBM low at the end of byte transmission */
+    LTC6810_2_SPI_WFCOM_HIGH = 0b1001   /*!< Transitions CSBM high at the end of byte transmission */
+};
+
+/*!
+ * \brief           I2C inital communication control bits on read
+ */
+enum Ltc68102I2cRicom {
+    LTC6811_I2C_RICOM_START = 0b0110,     /*!< Master generated a start signal */
+    LTC6811_I2C_RICOM_STOP = 0b0001,      /*!< Master generated a stop signal */
+    LTC6811_I2C_RICOM_BLANK = 0b0000,     /*!< SDA was held low between bytes */
+    LTC6811_I2C_RICOM_NOTRANSMIT = 0b0111 /*!< SDA was held high between bytes */
+};
+
+/*!
+ * \brief           I2C final communication control bits on read
+ */
+enum Ltc68102I2cRfcom {
+    LTC6810_2_I2C_RFCOM_MACK = 0b0000,      /*!< Master generated an ACK signal */
+    LTC6810_2_I2C_RFCOM_SACK = 0b0111,      /*!< Slave generated an ACK signal */
+    LTC6810_2_I2C_RFCOM_SNACK = 0b1111,     /*!< Slave generated a NACK signal */
+    LTC6810_2_I2C_RFCOM_SACK_STOP = 0b0001, /*!< Slave generated an ACK and master generated a STOP signal */
+    LTC6810_2_I2C_RFCOM_SNACK_STOP = 0b1001 /*!< Slave generated a NACK and master generated a STOP signal */
+};
+
+/*!
+ * \brief           SPI inital communication control bits on read
+ */
+enum Ltc68102SpiRicom {
+    LTC6810_2_SPI_RICOM = 0b0111
+};
+
+/*!
+ * \brief           SPI final communication control bits on read
+ */
+enum Ltc68102SpiRfcom {
+    LTC6810_2_SPI_RFCOM = 0b1111
+};
+
+/*!
+ * \brief           Configuration register group structure
+ */
+struct Ltc68102Cfgr {
+    uint8_t ADCOPT : 1; /*!< ADC mode option bit */
+    uint8_t DTEN : 1;   /*!< Discharge timer enable (READ ONLY) */
+    uint8_t REFON : 1;  /*!< References powered up */
+    uint8_t GPIO : 5;   /*!< GPIOx pin control (GPIO1 starts from the least significant bit) */
+    uint16_t VUV : 12;  /*!< Undervoltage comparison voltage */
+    uint16_t VOV : 12;  /*!< Overvoltage comparison voltage */
+    uint16_t DCC : 12;  /*!< Discharge cell x */
+    uint8_t DCTO : 4;   /*!< Discharge time out value */
+} __attribute__((__packed__));
+
+/*!
+ * \brief           Status register group structure
+ */
+struct Ltc68102Str {
+    uint16_t SC;         /*!< Sum of all cells measurement */
+    uint16_t ITMP;       /*!< Internal die temperature */
+    uint16_t VA;         /*!< Analog power supply voltage */
+    uint16_t VD;         /*!< Digital power supply voltage */
+    uint16_t COV : 12;   /*!< Cell over voltage flag */
+    uint16_t CUV : 12;   /*!< Cell under voltage flag */
+    uint8_t REV : 4;     /*!< Device revision code */
+    uint8_t RSVD : 2;    /*!< Reserved bits (always 0s) */
+    uint8_t MUXFAIL : 1; /*!< Multiplexer self test result */
+    uint8_t THSD : 1;    /*!< Thermal shutdown status */
+} __attribute__((__packed__));
+
+/*!
+ * \brief           External communication register group structure
+ *
+ * \details         The IC can be used as master for I2C and SPI communication
+ *                  via its GPIOs.
+ *                  For I2C:
+ *                      - GPIO4 is used as the Serial DAta(SDA)
+ *                      - GPIO5 is used as the Serial CLock(SCL)
+ *                  For SPI:
+ *                      - GPIO3 is used as the Chip Select(CSBM)
+ *                      - GPIO4 is used as the Serial Data Input-Output(SDIOM)
+ *                      - GPIO5 is used as the Serial Clock(SCKM)
+ *
+ * \warning         For SPI only mode 3 (CHPA = 1, CPOL = 1) is supported
+ */
+struct Ltc68102Comm {
+    uint8_t icom0 : 4;                     /*!< Initial communication control bits of the first data byte */
+    uint8_t icom1 : 4;                     /*!< Initial communication control bits of the second data byte */
+    uint8_t icom2 : 4;                     /*!< Initial communication control bits of the third data byte */
+    uint8_t fcom0 : 4;                     /*!< Final communication control bits of the first data byte */
+    uint8_t fcom1 : 4;                     /*!< Final communication control bits of the second data byte */
+    uint8_t fcom2 : 4;                     /*!< Final communication control bits of the third data byte */
+    uint8_t payload[LTC6810_2_COMM_COUNT]; /*!< Payload data transmited (received) to (from) I2C/SPI slave device */
+} __attribute__((__packed__));
+
+/*!
+ * \brief           LTC6810-2 handler structure
+ */
+struct Ltc68102Handler {
+    size_t count;
+};
+
+#endif

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -483,7 +483,8 @@ struct Ltc68102Str {
     uint16_t ITMP;            /*!< STAR2-3 Internal die temperature */
     uint16_t VA;              /*!< STAR4-5 Analog power supply voltage */
     uint16_t VD;              /*!< STBR0-1 Digital power supply voltage */
-    uint16_t cell_flags : 12; /*!< STBR2 + STBR3[3:0] interleaved CxUV/CxOV flags */
+    uint8_t COV : 6; /*!< Cell over voltage flag */
+    uint8_t CUV : 6; /*!< Cell under voltage flag */
     uint16_t MUTE : 1;        /*!< STBR3[4] Discharge mute status */
     uint16_t RSVD0 : 3;       /*!< STBR3[7:5] Reserved */
     uint8_t RSVD1;            /*!< STBR4 Reserved */

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -453,7 +453,7 @@ struct Ltc68102Cfgr {
     uint8_t DCC : 6;     /*!< CFGR4[5:0] Discharge cells 1..6 (DCC1..DCC6) */
     uint8_t MCAL : 1;    /*!< CFGR4[6] Multi-calibration enable */
     uint8_t DCC0 : 1;    /*!< CFGR4[7] Discharge 7th cell / S0 (DCC0) */
-    uint8_t DTMEN : 1;   /*!< CFGR5[0] Discharge timer monitor enable */
+    uint8_t EN_DTMEN : 1;   /*!< CFGR5[0] Discharge timer monitor enable */
     uint8_t DIS_RED : 1; /*!< CFGR5[1] Disable digital redundancy check */
     uint8_t FDRF : 1;    /*!< CFGR5[2] Force digital redundancy failure */
     uint8_t SCONV : 1;   /*!< CFGR5[3] Enable cell measurement redundancy via S pins */

--- a/include/drivers/ltc6810-2/ltc6810-2.h
+++ b/include/drivers/ltc6810-2/ltc6810-2.h
@@ -165,7 +165,7 @@ enum Ltc68102Command {
     LTC6810_2_CMD_ADSTATD = 0b10000001000, /*!< Start status group ADC conversion with digital redundancy and poll status */
     LTC6810_2_CMD_STATST = 0b10000001111,  /*!< Start self test status group conversion and poll status */
     LTC6810_2_CMD_ADCVAX = 0b10001101111,  /*!< Start combined cell voltage and GPIO1, GPIO2 conversion and poll status */
-    LTC6810_2_CMD_ADCVSC = 0b10001100111,  /*!< Start combined cell voltage and SC conversion and poll status */
+    LTC6810_2_CMD_ADCVSOC = 0b10001100111,  /*!< Start combined cell voltage and SC conversion and poll status */
 
     /*! Clear Register Commands */
     LTC6810_2_CMD_CLRCELL = 0b11100010001, /*!< Clear cell voltage register groups */

--- a/library.json
+++ b/library.json
@@ -6,6 +6,7 @@
     "keywords": [
         "bms-monitor",
         "ltc6811-1",
+        "ltc6810-2",
         "drivers",
         "embedded"
     ],
@@ -31,7 +32,9 @@
     ],
     "headers": [
         "ltc6811-1.h",
-        "ltc6811-1-api.h"
+        "ltc6811-1-api.h",
+        "ltc6810-2.h",
+        "ltc6810-2-api.h"
     ],
     "examples": [
         {
@@ -55,7 +58,8 @@
     },
     "build": {
         "flags": [
-            "-Iinclude/drivers/ltc6811-1"
+            "-Iinclude/drivers/ltc6811-1",
+            "-Iinclude/drivers/ltc6810-2"
         ]
     }
 }

--- a/src/drivers/ltc6810-2/ltc6810-2-api.c
+++ b/src/drivers/ltc6810-2/ltc6810-2-api.c
@@ -65,7 +65,7 @@ EAGLETRT_STATIC const uint16_t crcTable[] = {
  *
  * \param[in]       payload: The payload bytes
  * \param[in]       len: The length of the payload in bytes
- * \return          The calculated PEC
+ * \returns         uint16_t The calculated PEC
  */
 EAGLETRT_STATIC uint16_t prv_ltc6810_2_api_pec15(const uint8_t *const payload, const size_t len) {
     const uint16_t pec_seed = 16;
@@ -87,7 +87,7 @@ EAGLETRT_STATIC uint16_t prv_ltc6810_2_api_pec15(const uint8_t *const payload, c
  *
  * \param[in, out]  payload: The payload bytes
  * \param[in]       len: The length of the payload in bytes, PEC excluded
- * \return          The length of the payload in bytes, PEC included
+ * \returns         size_t The length of the payload in bytes, PEC included
  */
 EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_pec_calc(uint8_t *payload, size_t len) {
     uint16_t pec = prv_ltc6810_2_api_pec15(payload, len);
@@ -102,7 +102,7 @@ EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_pec_calc(uint8_t *payload, size_
  *
  * \param[in]       payload: The payload bytes
  * \param[in]       len: Length of the payload in bytes, PEC included
- * \return          True if the given and calculated PEC match, false otherwise
+ * \returns         bool True if the given and calculated PEC match, false otherwise
  */
 EAGLETRT_STATIC_INLINE bool prv_ltc6810_2_api_pec_is_correct(const uint8_t *payload, size_t len) {
     const uint8_t pec_offset_high = 8U;
@@ -122,7 +122,7 @@ EAGLETRT_STATIC_INLINE bool prv_ltc6810_2_api_pec_is_correct(const uint8_t *payl
  *
  * \param[in]       cmd: The command to copy
  * \param[out]      out: The array where command and PEC are stored
- * \return          The total number of encoded bytes, PEC included
+ * \returns         size_t The total number of encoded bytes, PEC included
  */
 EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_cmd_encode(enum Ltc68102Command cmd, uint8_t *out) {
     const uint8_t cmd_offset_high = 8U;
@@ -137,7 +137,7 @@ EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_cmd_encode(enum Ltc68102Command 
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       mode: The ADC conversion mode
- * \return          The given command with the ADC conversion mode set
+ * \returns         enum Ltc68102Command The given command with the ADC conversion mode set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_md(enum Ltc68102Command cmd, enum Ltc68102Md mode) {
     const uint8_t mode_offset = 7U;
@@ -150,7 +150,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_md(enum Lt
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       pup: The Pull-up/Pull-down option
- * \return          The given command with the Pull-up/Pull-down option set
+ * \returns         enum Ltc68102Command The given command with the Pull-up/Pull-down option set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_pup(enum Ltc68102Command cmd, enum Ltc68102Pup pup) {
     const uint8_t pup_offset = 6U;
@@ -162,7 +162,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_pup(enum L
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       mode: The self test mode option
- * \return          The given command with the self test mode set
+ * \returns         enum Ltc68102Command The given command with the self test mode set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_st(enum Ltc68102Command cmd, enum Ltc68102St mode) {
     const uint8_t mode_offset = 5U;
@@ -174,7 +174,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_st(enum Lt
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       dcp: The discharge permitted option
- * \return          The given command with the discharge option set
+ * \returns         enum Ltc68102CommandThe given command with the discharge option set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_dcp(enum Ltc68102Command cmd, enum Ltc68102Dcp dcp) {
     const uint8_t dcp_offset = 4U;
@@ -187,7 +187,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_dcp(enum L
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       cells: The selected cells
- * \return          The given command with the selected cells set
+ * \returns         enum Ltc68102Command The given command with the selected cells set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_ch(enum Ltc68102Command cmd, enum Ltc68102Ch cells) {
     return cells < LTC6810_2_CH_COUNT ? (cmd | (uint8_t)cells) : cmd;
@@ -199,7 +199,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_ch(enum Lt
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       gpios: The selected GPIOs
- * \return          The given command with the selected GPIOs set
+ * \returns         enum Ltc68102Command The given command with the selected GPIOs set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_chg(enum Ltc68102Command cmd, enum Ltc68102Chg gpios) {
     return gpios < LTC6810_2_CHG_COUNT ? (cmd | (uint8_t)gpios) : cmd;
@@ -211,7 +211,7 @@ EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_chg(enum L
  *
  * \param[in]       cmd: The command without the option set
  * \param[in]       groups: The selected status groups
- * \return          The given command with the selected status groups set
+ * \returns         enum Ltc68102Command The given command with the selected status groups set
  */
 EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_chst(enum Ltc68102Command cmd, enum Ltc68102Chst groups) {
     return groups < LTC6810_2_CHST_COUNT ? (cmd | (uint8_t)groups) : cmd;
@@ -244,7 +244,7 @@ size_t ltc6810_2_api_wrcfg_encode_broadcast(
         const size_t configIndex = handler->count - i - 1;
         const struct Ltc68102Cfgr *cfg = &(config[configIndex]);
 
-        out[encoded]     = (uint8_t)((cfg->GPIO << 3U) | (cfg->REFON << 2U) | (cfg->DTEN << 1U) | cfg->ADCOPT);
+        out[encoded] = (uint8_t)((cfg->GPIO << 3U) | (cfg->REFON << 2U) | (cfg->DTEN << 1U) | cfg->ADCOPT);
         out[encoded + 1] = (uint8_t)cfg->VUV;
         out[encoded + 2] = (uint8_t)((cfg->VOV << 4U) | (cfg->VUV >> 8U));
         out[encoded + 3] = (uint8_t)(cfg->VOV >> 4U);
@@ -437,12 +437,12 @@ size_t ltc6810_2_api_rdstat_decode_broadcast(
         if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
             switch (reg) {
                 case LTC6810_2_STAR:
-                    out[i].SC   = (uint16_t)(payload[off]     | (payload[off + 1] << 8U));
+                    out[i].SC = (uint16_t)(payload[off] | (payload[off + 1] << 8U));
                     out[i].ITMP = (uint16_t)(payload[off + 2] | (payload[off + 3] << 8U));
-                    out[i].VA   = (uint16_t)(payload[off + 4] | ((uint16_t)payload[off + 5] << 8U));
+                    out[i].VA = (uint16_t)(payload[off + 4] | ((uint16_t)payload[off + 5] << 8U));
                     break;
                 case LTC6810_2_STBR:
-                    out[i].VD   = (uint16_t)(payload[off] | (payload[off + 1] << 8U));
+                    out[i].VD = (uint16_t)(payload[off] | (payload[off + 1] << 8U));
                     // STBR2 = C4UV/C4OV..C1UV/C1OV (bits[7:0]), STBR3[3:0] = C6UV/C6OV..C5UV/C5OV
                     out[i].cell_flags = (uint16_t)(payload[off + 2] | ((payload[off + 3] & 0x0FU) << 8U));
                     out[i].MUTE = (payload[off + 3] >> 4) & 0x01;
@@ -855,7 +855,7 @@ size_t ltc6810_2_api_wrcomm_encode_broadcast(
     for (size_t i = 0; i < handler->count; ++i) {
         struct Ltc68102Comm *comm = &(comms[handler->count - i - 1]);
 
-        out[encoded]     = (uint8_t)((comm->ICOM0 << 4U) | comm->D0_hi);
+        out[encoded] = (uint8_t)((comm->ICOM0 << 4U) | comm->D0_hi);
         out[encoded + 1] = (uint8_t)((comm->D0_lo << 4U) | comm->FCOM0);
         out[encoded + 2] = (uint8_t)((comm->ICOM1 << 4U) | comm->D1_hi);
         out[encoded + 3] = (uint8_t)((comm->D1_lo << 4U) | comm->FCOM1);

--- a/src/drivers/ltc6810-2/ltc6810-2-api.c
+++ b/src/drivers/ltc6810-2/ltc6810-2-api.c
@@ -1,0 +1,991 @@
+/*!
+ * \file            ltc6810-2.c
+ * \date            2023-12-16
+ * \authors         Mirko Lana [mirko.lana@eagletrt.it]
+ *
+ * \brief           Function implementations needed for the LTC6810-2.
+ *
+ * \details         For additional information refer to the datasheet:
+ * \link            https://www.analog.com/media/en/technical-documentation/data-sheets/ltc6810-1-6810-2.pdf
+ */
+
+#include "ltc6810-2.h"
+#include "ltc6810-2-api.h"
+#include "eagletrt-api.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/types.h>
+
+/*!
+ * \brief           Table of precomputed values used to calculate the PEC for messaging
+ */
+// clang-format off
+EAGLETRT_STATIC const uint16_t crcTable[] = {
+    0x0000, 0xc599, 0xceab, 0x0b32, 0xd8cf, 0x1d56, 0x1664, 0xd3fd,
+    0xf407, 0x319e, 0x3aac, 0xff35, 0x2cc8, 0xe951, 0xe263, 0x27fa,
+    0xad97, 0x680e, 0x633c, 0xa6a5, 0x7558, 0xb0c1, 0xbbf3, 0x7e6a,
+    0x5990, 0x9c09, 0x973b, 0x52a2, 0x815f, 0x44c6, 0x4ff4, 0x8a6d,
+    0x5b2e, 0x9eb7, 0x9585, 0x501c, 0x83e1, 0x4678, 0x4d4a, 0x88d3,
+    0xaf29, 0x6ab0, 0x6182, 0xa41b, 0x77e6, 0xb27f, 0xb94d, 0x7cd4,
+    0xf6b9, 0x3320, 0x3812, 0xfd8b, 0x2e76, 0xebef, 0xe0dd, 0x2544,
+    0x02be, 0xc727, 0xcc15, 0x098c, 0xda71, 0x1fe8, 0x14da, 0xd143,
+    0xf3c5, 0x365c, 0x3d6e, 0xf8f7, 0x2b0a, 0xee93, 0xe5a1, 0x2038,
+    0x07c2, 0xc25b, 0xc969, 0x0cf0, 0xdf0d, 0x1a94, 0x11a6, 0xd43f,
+    0x5e52, 0x9bcb, 0x90f9, 0x5560, 0x869d, 0x4304, 0x4836, 0x8daf,
+    0xaa55, 0x6fcc, 0x64fe, 0xa167, 0x729a, 0xb703, 0xbc31, 0x79a8,
+    0xa8eb, 0x6d72, 0x6640, 0xa3d9, 0x7024, 0xb5bd, 0xbe8f, 0x7b16,
+    0x5cec, 0x9975, 0x9247, 0x57de, 0x8423, 0x41ba, 0x4a88, 0x8f11,
+    0x057c, 0xc0e5, 0xcbd7, 0x0e4e, 0xddb3, 0x182a, 0x1318, 0xd681,
+    0xf17b, 0x34e2, 0x3fd0, 0xfa49, 0x29b4, 0xec2d, 0xe71f, 0x2286,
+    0xa213, 0x678a, 0x6cb8, 0xa921, 0x7adc, 0xbf45, 0xb477, 0x71ee,
+    0x5614, 0x938d, 0x98bf, 0x5d26, 0x8edb, 0x4b42, 0x4070, 0x85e9,
+    0x0f84, 0xca1d, 0xc12f, 0x04b6, 0xd74b, 0x12d2, 0x19e0, 0xdc79,
+    0xfb83, 0x3e1a, 0x3528, 0xf0b1, 0x234c, 0xe6d5, 0xede7, 0x287e,
+    0xf93d, 0x3ca4, 0x3796, 0xf20f, 0x21f2, 0xe46b, 0xef59, 0x2ac0,
+    0x0d3a, 0xc8a3, 0xc391, 0x0608, 0xd5f5, 0x106c, 0x1b5e, 0xdec7,
+    0x54aa, 0x9133, 0x9a01, 0x5f98, 0x8c65, 0x49fc, 0x42ce, 0x8757,
+    0xa0ad, 0x6534, 0x6e06, 0xab9f, 0x7862, 0xbdfb, 0xb6c9, 0x7350,
+    0x51d6, 0x944f, 0x9f7d, 0x5ae4, 0x8919, 0x4c80, 0x47b2, 0x822b,
+    0xa5d1, 0x6048, 0x6b7a, 0xaee3, 0x7d1e, 0xb887, 0xb3b5, 0x762c,
+    0xfc41, 0x39d8, 0x32ea, 0xf773, 0x248e, 0xe117, 0xea25, 0x2fbc,
+    0x0846, 0xcddf, 0xc6ed, 0x0374, 0xd089, 0x1510, 0x1e22, 0xdbbb,
+    0x0af8, 0xcf61, 0xc453, 0x01ca, 0xd237, 0x17ae, 0x1c9c, 0xd905,
+    0xfeff, 0x3b66, 0x3054, 0xf5cd, 0x2630, 0xe3a9, 0xe89b, 0x2d02,
+    0xa76f, 0x62f6, 0x69c4, 0xac5d, 0x7fa0, 0xba39, 0xb10b, 0x7492,
+    0x5368, 0x96f1, 0x9dc3, 0x585a, 0x8ba7, 0x4e3e, 0x450c, 0x8095
+};
+// clang-format on
+
+/*!
+ * \brief           Generate the Packet Error Code (PEC) from an arbitrary
+ *                  payload
+ *
+ * \param[in]       payload: The payload bytes
+ * \param[in]       len: The length of the payload in bytes
+ * \return          The calculated PEC
+ */
+EAGLETRT_STATIC uint16_t prv_ltc6810_2_api_pec15(const uint8_t *const payload, const size_t len) {
+    const uint16_t pec_seed = 16;
+    uint16_t remainder = pec_seed;
+    for (size_t i = 0; i < len; ++i) {
+        // calculate PEC table address
+        uint16_t address = ((remainder >> 7) ^ payload[i]) & 0xff;
+        remainder = (uint16_t)((remainder << 8U) ^ crcTable[address]);
+    }
+    // The CRC15 has a 0 in the LSB so the final value must be multiplied by 2
+    return remainder * 2;
+}
+
+/*!
+ * \brief           Calculate and add the PEC to the payload array
+ *
+ * \warning         The array should have enough space to contain both the
+ *                  payload and the 2 bytes of PEC
+ *
+ * \param[in, out]  payload: The payload bytes
+ * \param[in]       len: The length of the payload in bytes, PEC excluded
+ * \return          The length of the payload in bytes, PEC included
+ */
+EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_pec_calc(uint8_t *payload, size_t len) {
+    uint16_t pec = prv_ltc6810_2_api_pec15(payload, len);
+    const uint8_t pec_offset_high = 8U;
+    payload[len] = (uint8_t)(pec >> pec_offset_high);
+    payload[len + 1] = (uint8_t)pec;
+    return len + LTC6810_2_PEC_BYTE_COUNT;
+}
+
+/*!
+ * \brief           Check if the received PEC is correct
+ *
+ * \param[in]       payload: The payload bytes
+ * \param[in]       len: Length of the payload in bytes, PEC included
+ * \return          True if the given and calculated PEC match, false otherwise
+ */
+EAGLETRT_STATIC_INLINE bool prv_ltc6810_2_api_pec_is_correct(const uint8_t *payload, size_t len) {
+    const uint8_t pec_offset_high = 8U;
+    uint16_t pec = (uint16_t)((payload[len - 2] << pec_offset_high) | payload[len - 1]);
+    return prv_ltc6810_2_api_pec15(payload, len - LTC6810_2_PEC_BYTE_COUNT) == pec;
+}
+
+/*!
+ * \brief           Copy the command and its calculated PEC inside a given
+ *                  array
+ *
+ * \warning         The given array has to be at least
+ *                  (LTC6810_2_CMD_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT)
+ *                  long. Only the first.
+ *                  (LTC6810_2_CMD_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT)
+ *                  bytes are modified
+ *
+ * \param[in]       cmd: The command to copy
+ * \param[out]      out: The array where command and PEC are stored
+ * \return          The total number of encoded bytes, PEC included
+ */
+EAGLETRT_STATIC_INLINE size_t prv_ltc6810_2_api_cmd_encode(enum Ltc68102Command cmd, uint8_t *out) {
+    const uint8_t cmd_offset_high = 8U;
+    const uint8_t cmd_mask_high = 0x07;
+    out[0] = (uint8_t)((cmd >> cmd_offset_high) & cmd_mask_high);
+    out[1] = (uint8_t)cmd;
+    return prv_ltc6810_2_api_pec_calc(out, 2);
+}
+
+/*!
+ * \brief           Set the ADC conversion mode option inside the given command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       mode: The ADC conversion mode
+ * \return          The given command with the ADC conversion mode set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_md(enum Ltc68102Command cmd, enum Ltc68102Md mode) {
+    const uint8_t mode_offset = 7U;
+    return mode < LTC6810_2_MD_COUNT ? (cmd | (mode << mode_offset)) : cmd;
+}
+
+/*!
+ * \brief           Set the Pull-up/Pull-down current for open-wire conversion
+ *                  option inside the given command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       pup: The Pull-up/Pull-down option
+ * \return          The given command with the Pull-up/Pull-down option set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_pup(enum Ltc68102Command cmd, enum Ltc68102Pup pup) {
+    const uint8_t pup_offset = 6U;
+    return pup < LTC6810_2_PUP_COUNT ? (cmd | (pup << pup_offset)) : cmd;
+}
+
+/*!
+ * \brief           Set the self test mode option inside the given command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       mode: The self test mode option
+ * \return          The given command with the self test mode set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_st(enum Ltc68102Command cmd, enum Ltc68102St mode) {
+    const uint8_t mode_offset = 5U;
+    return mode < LTC6810_2_ST_COUNT ? (cmd | (mode << mode_offset)) : cmd;
+}
+
+/*!
+ * \brief           Set the discharge permitted option inside the given command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       dcp: The discharge permitted option
+ * \return          The given command with the discharge option set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_dcp(enum Ltc68102Command cmd, enum Ltc68102Dcp dcp) {
+    const uint8_t dcp_offset = 4U;
+    return dcp < LTC6810_2_DCP_COUNT ? (cmd | (dcp << dcp_offset)) : cmd;
+}
+
+/*!
+ * \brief           Set the cell selection for ADC conversion inside the given
+ *                  command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       cells: The selected cells
+ * \return          The given command with the selected cells set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_ch(enum Ltc68102Command cmd, enum Ltc68102Ch cells) {
+    return cells < LTC6810_2_CH_COUNT ? (cmd | (uint8_t)cells) : cmd;
+}
+
+/*!
+ * \brief           Set the GPIOs selection for ADC conversion inside the given
+ *                  command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       gpios: The selected GPIOs
+ * \return          The given command with the selected GPIOs set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_chg(enum Ltc68102Command cmd, enum Ltc68102Chg gpios) {
+    return gpios < LTC6810_2_CHG_COUNT ? (cmd | (uint8_t)gpios) : cmd;
+}
+
+/*!
+ * \brief           Set the status group selection for ADC conversion inside
+ *                  the given command
+ *
+ * \param[in]       cmd: The command without the option set
+ * \param[in]       groups: The selected status groups
+ * \return          The given command with the selected status groups set
+ */
+EAGLETRT_STATIC_INLINE enum Ltc68102Command prv_ltc6810_2_api_cmd_set_chst(enum Ltc68102Command cmd, enum Ltc68102Chst groups) {
+    return groups < LTC6810_2_CHST_COUNT ? (cmd | (uint8_t)groups) : cmd;
+}
+
+void ltc6810_2_api_init(struct Ltc68102Handler *handler, size_t ltc_count) {
+    if (handler == NULL) {
+        return;
+    }
+    memset(handler, 0, sizeof(*handler));
+    handler->count = EAGLETRT_API_MAX(1U, ltc_count);
+}
+
+bool ltc6810_2_api_pladc_is_completed(const uint8_t byte) {
+    return byte == LTC6810_2_PLADC_COMPLETE_BYTE_VALUE;
+}
+
+size_t ltc6810_2_api_wrcfg_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    struct Ltc68102Cfgr *config,
+    uint8_t *out) {
+    if (handler == NULL || config == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_WRCFG;
+    size_t encoded = prv_ltc6810_2_api_cmd_encode(cmd, out);
+
+    for (size_t i = 0; i < handler->count; ++i) {
+        const size_t configIndex = handler->count - i - 1;
+        const struct Ltc68102Cfgr *cfg = &(config[configIndex]);
+
+        out[encoded]     = (uint8_t)((cfg->GPIO << 3U) | (cfg->REFON << 2U) | (cfg->DTEN << 1U) | cfg->ADCOPT);
+        out[encoded + 1] = (uint8_t)cfg->VUV;
+        out[encoded + 2] = (uint8_t)((cfg->VOV << 4U) | (cfg->VUV >> 8U));
+        out[encoded + 3] = (uint8_t)(cfg->VOV >> 4U);
+        out[encoded + 4] = (uint8_t)(((cfg->DCC0 & 1U) << 7U) | ((cfg->MCAL & 1U) << 6U) | (cfg->DCC & 0x3FU));
+        out[encoded + 5] = (uint8_t)((cfg->DCTO << 4U) | (cfg->SCONV << 3U) | (cfg->FDRF << 2U) | (cfg->DIS_RED << 1U) | cfg->DTMEN);
+
+        encoded += prv_ltc6810_2_api_pec_calc(out + encoded, LTC6810_2_REG_BYTE_COUNT);
+    }
+    return encoded;
+}
+
+size_t ltc6810_2_api_rdcfg_encode_broadcast(const struct Ltc68102Handler *handler, uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    return prv_ltc6810_2_api_cmd_encode(LTC6810_2_CMD_RDCFG, out);
+}
+
+size_t ltc6810_2_api_rdcfg_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    struct Ltc68102Cfgr *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            // Decode configuration payload
+            out[i].ADCOPT = payload[off] & 0x01;
+            out[i].DTEN = (payload[off] & 0x02) >> 1;
+            out[i].REFON = (payload[off] & 0x04) >> 2;
+            out[i].GPIO = (payload[off] & 0xF8) >> 3;
+            out[i].VUV = (uint16_t)(payload[off + 1] | ((payload[off + 2] & 0x0FU) << 8U));
+            out[i].VOV = (uint16_t)(((payload[off + 2] & 0xF0U) >> 4U) | ((uint32_t)payload[off + 3] << 4U));
+            out[i].DCC = payload[off + 4] & 0x3F;
+            out[i].MCAL = (payload[off + 4] >> 6) & 0x01;
+            out[i].DCC0 = (payload[off + 4] >> 7) & 0x01;
+            out[i].DTMEN = payload[off + 5] & 0x01;
+            out[i].DIS_RED = (payload[off + 5] >> 1) & 0x01;
+            out[i].FDRF = (payload[off + 5] >> 2) & 0x01;
+            out[i].SCONV = (payload[off + 5] >> 3) & 0x01;
+            out[i].DCTO = (payload[off + 5] >> 4) & 0x0F;
+
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_rdcv_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Cvxr reg,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDCVA;
+    switch (reg) {
+        case LTC6810_2_CVAR:
+            cmd = LTC6810_2_CMD_RDCVA;
+            break;
+        case LTC6810_2_CVBR:
+            cmd = LTC6810_2_CMD_RDCVB;
+            break;
+        case LTC6810_2_CVCR:
+            cmd = LTC6810_2_CMD_RDSA;
+            break;
+        case LTC6810_2_CVDR:
+            cmd = LTC6810_2_CMD_RDSB;
+            break;
+        default:
+            cmd = LTC6810_2_CMD_RDCVA;
+            break;
+    }
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdcv_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint16_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            // For each cell voltage in register
+            for (size_t j = 0; j < LTC6810_2_REG_CELL_COUNT; ++j) {
+                size_t cell_off = off + j * sizeof(uint16_t);
+                out[i * LTC6810_2_REG_CELL_COUNT + j] = (uint16_t)(payload[cell_off] | (payload[cell_off + 1] << 8U));
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_rdaux_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Avxr reg,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDAUXA;
+    switch (reg) {
+        case LTC6810_2_AVAR:
+            cmd = LTC6810_2_CMD_RDAUXA;
+            break;
+        case LTC6810_2_AVBR:
+            cmd = LTC6810_2_CMD_RDAUXB;
+            break;
+        default:
+            cmd = LTC6810_2_CMD_RDAUXA;
+            break;
+    }
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdaux_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint16_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            // For each voltage in register
+            for (size_t j = 0; j < LTC6810_2_REG_AUX_COUNT; ++j) {
+                size_t cell_off = off + j * sizeof(uint16_t);
+                out[i * LTC6810_2_REG_AUX_COUNT + j] = (uint16_t)(payload[cell_off] | (payload[cell_off + 1] << 8U));
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_rdstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Stxr reg,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDSTATA;
+    switch (reg) {
+        case LTC6810_2_STAR:
+            cmd = LTC6810_2_CMD_RDSTATA;
+            break;
+        case LTC6810_2_STBR:
+            cmd = LTC6810_2_CMD_RDSTATB;
+            break;
+        default:
+            cmd = LTC6810_2_CMD_RDSTATA;
+            break;
+    }
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdstat_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Stxr reg,
+    const uint8_t *payload,
+    struct Ltc68102Str *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        // Check PEC validity
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            switch (reg) {
+                case LTC6810_2_STAR:
+                    out[i].SC   = (uint16_t)(payload[off]     | (payload[off + 1] << 8U));
+                    out[i].ITMP = (uint16_t)(payload[off + 2] | (payload[off + 3] << 8U));
+                    out[i].VA   = (uint16_t)(payload[off + 4] | ((uint16_t)payload[off + 5] << 8U));
+                    break;
+                case LTC6810_2_STBR:
+                    out[i].VD   = (uint16_t)(payload[off] | (payload[off + 1] << 8U));
+                    // STBR2 = C4UV/C4OV..C1UV/C1OV (bits[7:0]), STBR3[3:0] = C6UV/C6OV..C5UV/C5OV
+                    out[i].cell_flags = (uint16_t)(payload[off + 2] | ((payload[off + 3] & 0x0FU) << 8U));
+                    out[i].MUTE = (payload[off + 3] >> 4) & 0x01;
+                    out[i].RSVD0 = (payload[off + 3] >> 5) & 0x07;
+                    out[i].RSVD1 = payload[off + 4];
+                    out[i].THSD = payload[off + 5] & 0x01;
+                    out[i].MUXFAIL = (payload[off + 5] >> 1) & 0x01;
+                    out[i].RSVD2 = (payload[off + 5] >> 2) & 0x03;
+                    out[i].REV = (payload[off + 5] >> 4) & 0x0F;
+                    break;
+                default:
+                    return 0U;
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_wrsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_WRSCTRL;
+    size_t encoded = prv_ltc6810_2_api_cmd_encode(cmd, out);
+
+    // Encode data with corresponsing PEC
+    for (size_t i = 0; i < handler->count; ++i) {
+        for (size_t byte = 0; byte < LTC6810_2_REG_BYTE_COUNT; ++byte) {
+            const size_t ltcIndex = handler->count - i - 1;
+            const size_t index = ltcIndex * LTC6810_2_REG_SCTRL_COUNT + byte * 2;
+            out[encoded + byte] = (uint8_t)((payload[index] & 0x0FU) | ((payload[index + 1] & 0x0FU) << 4U));
+        }
+        encoded += prv_ltc6810_2_api_pec_calc(out + encoded, LTC6810_2_REG_BYTE_COUNT);
+    }
+    return encoded;
+}
+
+size_t ltc6810_2_api_rdsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDSCTRL;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdsctrl_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        // Check PEC validity
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            // For each payload byte
+            for (size_t byte = 0; byte < LTC6810_2_REG_BYTE_COUNT; ++byte) {
+                size_t index = i * LTC6810_2_REG_SCTRL_COUNT + byte * 2;
+                out[index] = payload[off + byte] & 0x0F;
+                out[index + 1] = payload[off + byte] >> 4;
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_stsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    enum Ltc68102Command cmd = LTC6810_2_CMD_STSCTRL;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_clrsctrl_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    enum Ltc68102Command cmd = LTC6810_2_CMD_CLRSCTRL;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_wrpwm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_WRPWM;
+    size_t encoded = prv_ltc6810_2_api_cmd_encode(cmd, out);
+
+    // Encode data with corresponsing PEC
+    for (size_t i = 0; i < handler->count; ++i) {
+        for (size_t byte = 0; byte < LTC6810_2_REG_BYTE_COUNT; ++byte) {
+            const size_t ltcIndex = handler->count - i - 1;
+            const size_t index = ltcIndex * LTC6810_2_REG_PWM_COUNT + byte * 2;
+            out[encoded + byte] = (uint8_t)((payload[index] & 0x0FU) | ((payload[index + 1] & 0x0FU) << 4U));
+        }
+        encoded += prv_ltc6810_2_api_pec_calc(out + encoded, LTC6810_2_REG_BYTE_COUNT);
+    }
+    return encoded;
+}
+
+size_t ltc6810_2_api_rdpwm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDPWM;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdpwm_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            // For each payload byte
+            for (size_t byte = 0; byte < LTC6810_2_REG_BYTE_COUNT; ++byte) {
+                size_t index = i * LTC6810_2_PWM_COUNT + byte * 2;
+                out[index] = payload[off + byte] & 0x0F;
+                out[index + 1] = payload[off + byte] >> 4;
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_adcv_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    enum Ltc68102Ch cells,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADCV;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_dcp(cmd, dcp);
+    cmd = prv_ltc6810_2_api_cmd_set_ch(cmd, cells);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adow_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Pup pup,
+    enum Ltc68102Dcp dcp,
+    enum Ltc68102Ch cells,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADOW;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_pup(cmd, pup);
+    cmd = prv_ltc6810_2_api_cmd_set_dcp(cmd, dcp);
+    cmd = prv_ltc6810_2_api_cmd_set_ch(cmd, cells);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_cvst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_CVST;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_st(cmd, test_mode);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adol_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADOL;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_dcp(cmd, dcp);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adax_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADAX;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_chg(cmd, gpios);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adaxd_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADAXD;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_chg(cmd, gpios);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_axst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_AXST;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_st(cmd, test_mode);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chst groups,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADSTAT;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_chst(cmd, groups);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adstatd_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chst groups,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADSTATD;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_chst(cmd, groups);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_statst_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102St test_mode,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_STATST;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_st(cmd, test_mode);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adcvax_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADCVAX;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_dcp(cmd, dcp);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_adcvsc_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Dcp dcp,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_ADCVSC;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_dcp(cmd, dcp);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_clrcell_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_CLRCELL;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_clraux_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_CLRAUX;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_clrstat_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_CLRSTAT;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_pladc_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_PLADC;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_diagn_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_DIAGN;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_wrcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    struct Ltc68102Comm *comms,
+    uint8_t *out) {
+    if (handler == NULL || comms == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_WRCOMM;
+
+    size_t encoded = prv_ltc6810_2_api_cmd_encode(cmd, out);
+    for (size_t i = 0; i < handler->count; ++i) {
+        struct Ltc68102Comm *comm = &(comms[handler->count - i - 1]);
+
+        out[encoded]     = (uint8_t)((comm->ICOM0 << 4U) | comm->D0_hi);
+        out[encoded + 1] = (uint8_t)((comm->D0_lo << 4U) | comm->FCOM0);
+        out[encoded + 2] = (uint8_t)((comm->ICOM1 << 4U) | comm->D1_hi);
+        out[encoded + 3] = (uint8_t)((comm->D1_lo << 4U) | comm->FCOM1);
+        out[encoded + 4] = (uint8_t)((comm->ICOM2 << 4U) | comm->D2_hi);
+        out[encoded + 5] = (uint8_t)((comm->D2_lo << 4U) | comm->FCOM2);
+
+        encoded += prv_ltc6810_2_api_pec_calc(out + encoded, LTC6810_2_REG_BYTE_COUNT);
+    }
+    return encoded;
+}
+
+size_t ltc6810_2_api_rdcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_RDCOMM;
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}
+
+size_t ltc6810_2_api_rdcomm_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    struct Ltc68102Comm *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        // Check PEC validity
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            out[i].ICOM0 = payload[off + 0] >> 4;
+            out[i].D0_hi = payload[off + 0] & 0x0F;
+            out[i].D0_lo = payload[off + 1] >> 4;
+            out[i].FCOM0 = payload[off + 1] & 0x0F;
+            out[i].ICOM1 = payload[off + 2] >> 4;
+            out[i].D1_hi = payload[off + 2] & 0x0F;
+            out[i].D1_lo = payload[off + 3] >> 4;
+            out[i].FCOM1 = payload[off + 3] & 0x0F;
+            out[i].ICOM2 = payload[off + 4] >> 4;
+            out[i].D2_hi = payload[off + 4] & 0x0F;
+            out[i].D2_lo = payload[off + 5] >> 4;
+            out[i].FCOM2 = payload[off + 5] & 0x0F;
+
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_stcomm_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_STCOMM;
+    size_t encoded = prv_ltc6810_2_api_cmd_encode(cmd, out);
+
+    memset(out + encoded, 0xff, LTC6810_2_STCOMM_CYCLES);
+    encoded += LTC6810_2_STCOMM_CYCLES;
+    return encoded;
+}
+
+size_t ltc6810_2_api_mute_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    return prv_ltc6810_2_api_cmd_encode(LTC6810_2_CMD_MUTE, out);
+}
+
+size_t ltc6810_2_api_unmute_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    return prv_ltc6810_2_api_cmd_encode(LTC6810_2_CMD_UNMUTE, out);
+}
+
+size_t ltc6810_2_api_rdsid_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+    return prv_ltc6810_2_api_cmd_encode(LTC6810_2_CMD_RDSID, out);
+}
+
+size_t ltc6810_2_api_rdsid_decode_broadcast(
+    const struct Ltc68102Handler *handler,
+    const uint8_t *payload,
+    uint8_t *out) {
+    if (handler == NULL || payload == NULL || out == NULL) {
+        return 0U;
+    }
+
+    size_t decoded = 0, off = 0;
+    const size_t byte_count = LTC6810_2_REG_BYTE_COUNT + LTC6810_2_PEC_BYTE_COUNT;
+    for (size_t i = 0; i < handler->count; ++i) {
+        if (prv_ltc6810_2_api_pec_is_correct(payload + off, byte_count)) {
+            for (size_t j = 0; j < LTC6810_2_REG_BYTE_COUNT; ++j) {
+                out[i * LTC6810_2_REG_BYTE_COUNT + j] = payload[off + j];
+            }
+            decoded += byte_count;
+        }
+        off += byte_count;
+    }
+    return decoded;
+}
+
+size_t ltc6810_2_api_axow_encode_broadcast(
+    const struct Ltc68102Handler *handler,
+    enum Ltc68102Md mode,
+    enum Ltc68102Chg gpios,
+    uint8_t *out) {
+    if (handler == NULL || out == NULL) {
+        return 0U;
+    }
+
+    enum Ltc68102Command cmd = LTC6810_2_CMD_AXOW;
+    cmd = prv_ltc6810_2_api_cmd_set_md(cmd, mode);
+    cmd = prv_ltc6810_2_api_cmd_set_chg(cmd, gpios);
+    return prv_ltc6810_2_api_cmd_encode(cmd, out);
+}


### PR DESCRIPTION
# Purpose
Complete the LTC6810-2 API driver. Add missing commands, fix register encoding, and eliminate narrowing conversions. Adapt the driver fully from its LTC6811-1 origin to the LTC6810-2 variant. Closes #5.

# Overview
- Adapted `ltc6810-2-api.c` from the LTC6811-1 driver; pure encode/decode, no SPI calls or side effects (callers own the transfer).
- Rewrote CFGR byte 4/5 packing in `wrcfg_encode_broadcast` to encode all 6810-2 fields: `DCC0`, `MCAL`, `DCC6..DCC1`, `DCTO`, `SCONV`, `FDRF`, `DIS_RED`, `DTMEN` (previously DCC bits only).
- Rewrote matching decode in `rdcfg_decode_broadcast` for all 6 new fields.
- Fixed `rdstat_decode_broadcast` STBR: replaced non-existent `CUV`/`COV`/`RSVD` with `cell_flags`, `MUTE`, `RSVD0/1/2` per `Ltc68102Str`.
- Fixed `wrcomm_encode_broadcast` / `rdcomm_decode_broadcast` to use the 6810-2 split-nibble COMM layout (`ICOM0`, `D0_hi`, `D0_lo`, `FCOM0`, …) instead of the 6811-1 `icom0`/`fcom0`/`payload[]` layout.
- Added 5 missing commands: `mute_encode_broadcast` (MUTE 0x028), `unmute_encode_broadcast` (UNMUTE 0x029), `rdsid_encode_broadcast` / `rdsid_decode_broadcast` (RDSID 0x02C), `axow_encode_broadcast` (AXOW 0x450).

# Guidance
- **`ltc6810-2-api.c` (CFGR4/5)**: verify byte packing matches the register map; `CFGR4 = [DCC0][MCAL][DCC6..DCC1]`, `CFGR5 = [DCTO[3:0]][SCONV][FDRF][DIS_RED][DTMEN]`.
- **PEC**: confirm the `remainder` seed is `0x0010` (not 0) and that the per-iteration `(uint16_t)` cast on the XOR result is preserved, without it the accumulator widens and produces a wrong PEC.
- **COMM register**: check the split-nibble wire encoding (`Dn = (Dn_hi << 4) | Dn_lo`) and the ICOM/FCOM code tables against the datasheet.
- **New commands**: review MUTE/UNMUTE (discharge pause without clearing DCC) and RDSID decode (PEC verified per device; failed devices contribute 0 but still advance `off`).
